### PR TITLE
feat: redirect after login

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useAuthContext } from "@/contexts/AuthContext";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import React from "react";
 
 export default function AuthLayout({
@@ -9,9 +9,12 @@ export default function AuthLayout({
   children: React.ReactNode;
 }>) {
   const { user } = useAuthContext();
+  const searchParams = useSearchParams();
+
+  const redirectUrl = searchParams.get("redirect");
   const router = useRouter();
   if (user) {
-    router.push("/");
+    router.push(redirectUrl ? decodeURIComponent(redirectUrl) : "/");
     return null;
   } else {
     return (

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useAuthContext } from "@/contexts/AuthContext";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import Sidebar from "@/components/Layouts/Sidebar";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
@@ -13,9 +13,9 @@ export default function RootLayout({
 }>) {
   const { user } = useAuthContext();
   const router = useRouter();
-
+  const pathname = usePathname();
   if (user == null) {
-    router.push("/sign-in");
+    router.push(`/sign-in?redirect=${encodeURIComponent(pathname)}`); 
     return null;
   }
 


### PR DESCRIPTION
If a user who isn't logged in tries to access a protected route, they are redirected to the `/sign-in` page. The original route is sent as a query parameter, so after signing in, the user is automatically redirected back to the page they initially wanted to access.
