### PR TITLE
Patch: unable to chat for shared chat 

### DIFF
--- a/app/(main)/chat/[chatId]/page.tsx
+++ b/app/(main)/chat/[chatId]/page.tsx
@@ -172,7 +172,7 @@ const Chat = ({ params }: { params: { chatId: string } }) => {
       }
 
       setIsCreator(info.is_creator);
-      setChatAccess(info.is_creator ? "write" : "read");
+      setChatAccess(info.is_creator ? "write" : info.access_type);
       setCurrentConversation((prevConversation: any) => ({
         ...prevConversation,
         totalMessages: info.total_messages,


### PR DESCRIPTION
If the user is creator of chat given `write` access else `access_type` is assigned which is returned form 
```/api/v1/conversations/{conversation_id}/info/```