### PR TITLE
fix: long words in markdown

### DIFF
--- a/app/(main)/chat/[chatId]/components/Thread.tsx
+++ b/app/(main)/chat/[chatId]/components/Thread.tsx
@@ -4,7 +4,6 @@ import {
   ComposerPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
-  useAssistantRuntime,
   useComposerRuntime,
   useMessage,
   useMessageRuntime,
@@ -26,7 +25,6 @@ import ReactMarkdown from "react-markdown";
 import MyCodeBlock from "@/components/codeBlock";
 import MessageComposer from "./MessageComposer";
 import remarkGfm from "remark-gfm";
-import { useAuthContext } from "@/contexts/AuthContext";
 
 interface ThreadProps {
   projectId: string;
@@ -151,7 +149,7 @@ const CustomMarkdown = ({ content }: { content: string }) => {
 
   return (
     <ReactMarkdown
-      className="markdown-content [&_p]:!leading-tight [&_p]:!my-0.5 [&_li]:!my-0.5 animate-blink"
+      className="markdown-content break-words break-before-avoid [&_p]:!leading-tight [&_p]:!my-0.5 [&_li]:!my-0.5 animate-blink"
       components={{
         code: ({ children }) => (
           <span className="whitespace-pre-wrap">


### PR DESCRIPTION
Fix markdown overflowing issue, break longer words to new line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the display of markdown content with improved text wrapping and line break behavior, resulting in a cleaner and more readable view for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->