### PR TITLE
fix: long words in markdown

### DIFF
--- a/app/(main)/chat/[chatId]/components/Thread.tsx
+++ b/app/(main)/chat/[chatId]/components/Thread.tsx
@@ -178,7 +178,7 @@ const MarkdownComponent = (content: any) => {
               <CustomMarkdown content={section.content} />
             )}
             {section.type === "code" && (
-              <div className="pb-4 text-xs">
+              <div className="pb-4 text-xs max-w-4xl">
                 <MyCodeBlock
                   code={section.content}
                   language={section.language || "json"}

--- a/app/(main)/chat/[chatId]/components/Thread.tsx
+++ b/app/(main)/chat/[chatId]/components/Thread.tsx
@@ -4,7 +4,6 @@ import {
   ComposerPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
-  useAssistantRuntime,
   useComposerRuntime,
   useMessage,
   useMessageRuntime,
@@ -26,7 +25,6 @@ import ReactMarkdown from "react-markdown";
 import MyCodeBlock from "@/components/codeBlock";
 import MessageComposer from "./MessageComposer";
 import remarkGfm from "remark-gfm";
-import { useAuthContext } from "@/contexts/AuthContext";
 
 interface ThreadProps {
   projectId: string;
@@ -151,7 +149,7 @@ const CustomMarkdown = ({ content }: { content: string }) => {
 
   return (
     <ReactMarkdown
-      className="markdown-content [&_p]:!leading-tight [&_p]:!my-0.5 [&_li]:!my-0.5 animate-blink"
+      className="markdown-content break-words break-before-avoid [&_p]:!leading-tight [&_p]:!my-0.5 [&_li]:!my-0.5 animate-blink"
       components={{
         code: ({ children }) => (
           <span className="whitespace-pre-wrap">


### PR DESCRIPTION
Break long words in markdown to fix overflowing text issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced markdown text display in chat threads for a cleaner reading experience. The improved styling now provides better word wrapping and more natural line breaks, ensuring that messages are easier to read. 
  - Adjusted maximum width for code block display in markdown components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->