### PR TITLE
fix: work break in code blocks

### DIFF
--- a/components/codeBlock.tsx
+++ b/components/codeBlock.tsx
@@ -37,9 +37,7 @@ function MyCodeBlock({ code, language }: MyCodeBlockProps) {
           <div className="table-row">
             {/* <CodeBlock.LineNumber className="table-cell pr-4 text-sm text-border text-right select-none" /> */}
             <CodeBlock.LineContent className="table-cell">
-              <div className="whitespace-pre-wrap break-words">
                 <CodeBlock.Token />
-              </div>
             </CodeBlock.LineContent>
           </div>
         </CodeBlock.Code>


### PR DESCRIPTION
Fix line breaks occuring in code blocks. Code Blocks have overflow scroll horizontally, no need of line breaks which might cause unknown behaviour for copied code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the rendering of code blocks by simplifying the layout structure. The display remains unchanged for users while the internal markup is more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->