### PR TITLE
fix: improve chat step opacity for better UX

### DIFF
--- a/app/(main)/newchat/page.tsx
+++ b/app/(main)/newchat/page.tsx
@@ -50,13 +50,13 @@ const NewChat = () => {
         {steps.map((step, index) => (
           <div
             key={index}
-            className={`flex items-start mb-4 w-full relative ${chatStep === step.label ? "" : "pointer-events-none"}`}
+            className={`flex items-start mb-4 w-full relative ${chatStep === step.label ? "" : "pointer-events-none opacity-50"}`}
           >
             <div
               className={`absolute left-[15px] top-8 h-full border-l-2 border-gray-300 z-0 ${index === steps.length - 1 ? "hidden" : "top-10"}`}
             ></div>
             <div
-              className={`flex items-center justify-center w-8 h-8 rounded-full z-5 ${
+              className={`flex items-center justify-center w-8 h-8 rounded-full z-5 flex-shrink-0 ${
                 step.label === 3 && chatStep === 3 
                   ? "bg-green-100 text-green-600 border-2 border-green-500" 
                   : step.label <= chatStep 


### PR DESCRIPTION
Optimize the following points:
1. Disable flex shrink for step element.
2. Add opacity for disabled steps.

Before:
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/c6c757c7-7834-4f0e-b79c-765f7a6e156f" />

After:
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/ee00169f-8cb0-4cee-b5b9-ca0ef97fedf9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Inactive steps in the multi-step chat creation UI are now visually dimmed for improved clarity.
  - Step indicator circles are prevented from shrinking, ensuring consistent appearance across different layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->