### PR TITLE
Handle repos without full_name on new chat

### DIFF
--- a/app/(main)/newchat/components/step1.tsx
+++ b/app/(main)/newchat/components/step1.tsx
@@ -207,7 +207,13 @@ const Step1: React.FC<Step1Props> = ({
       queryFn: async () => {
         const repos = await BranchAndRepositoryService.getUserRepositories().then((data) => {
           if (defaultRepo && data.length > 0 ) {
-            if (defaultRepo && data.length > 0) {
+            const decodedDefaultRepo = decodeURIComponent(defaultRepo).toLowerCase();
+            const matchingRepo = data.find((repo: { full_name?: string | null; owner?: string | null; name?: string | null }) => {
+              const repoIdentifier = getRepoIdentifier(repo);
+              return repoIdentifier && repoIdentifier.toLowerCase() === decodedDefaultRepo;
+            });
+            dispatch(setRepoName(matchingRepo ? decodeURIComponent(defaultRepo) : ""));
+          }
               const decodedDefaultRepo = decodeURIComponent(defaultRepo).toLowerCase();
               const matchingRepo = data.find((repo: { full_name?: string | null; owner?: string | null; name?: string | null }) => {
                 const repoIdentifier = getRepoIdentifier(repo);


### PR DESCRIPTION
## Summary
- prevent new chat repo selector from crashing when repo.full_name is null
- introduce helper to derive repo identifiers from owner/name fallback
- ensure repo dropdown renders and selects using safe identifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository matching so the correct repo is consistently selected in the new chat flow regardless of identifier format.
  * Repository list now displays stable repository identifiers and skips invalid entries.
  * Selecting a repository reliably updates the selection and closes the chooser popover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->