### PR TITLE
fix: display GitHub account already linked error messages in frontend

### DIFF
--- a/app/(auth)/link-github/page.tsx
+++ b/app/(auth)/link-github/page.tsx
@@ -78,7 +78,14 @@ const LinkGithub = () => {
           return res.data;
         })
         .catch((e: any) => {
-          toast.error("Signup call unsuccessful");
+          // Check for 409 Conflict (GitHub already linked)
+          if (e?.response?.status === 409 && e?.response?.data?.error) {
+            toast.error(e.response.data.error);
+          } else if (e?.response?.data?.error) {
+            toast.error(e.response.data.error);
+          } else {
+            toast.error("Signup call unsuccessful");
+          }
         });
       toast.success(
         "Account created successfully as  " + result.user.displayName

--- a/lib/utils/errorMessages.ts
+++ b/lib/utils/errorMessages.ts
@@ -8,6 +8,19 @@ export function getUserFriendlyError(error: any): string {
     return getUserFriendlyMessage(error);
   }
 
+  // Check for 409 Conflict status (e.g., GitHub account already linked)
+  if (error?.response?.status === 409) {
+    const errorData = error.response.data;
+    // Use the error message from backend, which is user-friendly
+    if (errorData?.error) {
+      return errorData.error;
+    }
+    // Fallback to details if error field not available
+    if (errorData?.details) {
+      return errorData.details;
+    }
+  }
+
   // Extract error message from various error object formats
   let errorMessage = '';
   
@@ -18,6 +31,9 @@ export function getUserFriendlyError(error: any): string {
     errorMessage = error.response.data.error;
   } else if (error?.response?.data?.message) {
     errorMessage = error.response.data.message;
+  } else if (error?.response?.data?.details) {
+    // Check details field as fallback
+    errorMessage = error.response.data.details;
   } else if (error?.message) {
     errorMessage = error.message;
   } else if (typeof error === 'string') {
@@ -81,6 +97,11 @@ function getUserFriendlyMessage(message: string): string {
       return 'The linking request has expired. Please try linking again.';
     }
     return 'Failed to link account. Please try again.';
+  }
+  
+  // GitHub account already linked to another user
+  if (lowerMessage.includes('github account') && lowerMessage.includes('already linked')) {
+    return 'This GitHub account is already linked to another account. Please use a different GitHub account or contact support if you believe this is an error.';
   }
 
   // Network/API errors

--- a/services/AuthService.ts
+++ b/services/AuthService.ts
@@ -61,8 +61,12 @@ export default class AuthService {
       if (process.env.NODE_ENV !== 'production') {
         console.error("Signup API error:", error);
       }
+      // Check for 409 Conflict (GitHub already linked) or other errors
       const errorMessage =
-        error.response?.data?.error || "Signup call unsuccessful";
+        error.response?.data?.error || 
+        error.response?.data?.details ||
+        error.message ||
+        "Signup call unsuccessful";
       throw new Error(errorMessage);
     }
   }
@@ -105,7 +109,13 @@ export default class AuthService {
       if (process.env.NODE_ENV !== 'production') {
         console.error("GitHub signup API error:", error);
       }
-      throw new Error("Sign-in unsuccessful");
+      // Check for 409 Conflict (GitHub already linked) or other errors
+      const errorMessage =
+        error.response?.data?.error || 
+        error.response?.data?.details ||
+        error.message ||
+        "Sign-in unsuccessful";
+      throw new Error(errorMessage);
     }
   }
 


### PR DESCRIPTION
- Add 409 Conflict status code handling in getUserFriendlyError
- Check for error.response.data.details field as fallback
- Add specific error message for GitHub account already linked scenario
- Update link-github page to display backend error messages
- Update AuthService to extract and display error details from backend
- Ensure user-friendly error messages match backend logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced error messages during signup and GitHub account linking processes to provide users with more descriptive feedback.
* Improved error handling across authentication flows to display clearer and more informative messages when authentication fails.
* Added specific user guidance for GitHub account linking conflicts with improved fallback error messaging support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->