### PR TITLE
feat: Set Firebase authentication persistence to local storage

### DIFF
--- a/configs/Firebase-config.ts
+++ b/configs/Firebase-config.ts
@@ -5,6 +5,8 @@ import {
   onIdTokenChanged as firebaseOnIdTokenChanged,
   onAuthStateChanged as firebaseOnAuthStateChanged,
   signInWithPopup as firebaseSignInWithPopup,
+  setPersistence,
+  browserLocalPersistence,
   NextOrObserver,
   User,
   Unsubscribe
@@ -43,6 +45,15 @@ if (hasRequiredConfig) {
     firebase_app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
     db = getFirestore(firebase_app);
     auth = getAuth(firebase_app);
+    
+    // Set persistence to LOCAL (uses IndexedDB) instead of SESSION (sessionStorage)
+    // This is crucial for production environments with storage partitioning (Safari, privacy-focused browsers)
+    // IndexedDB is more reliable than sessionStorage in cross-origin/privacy-protected contexts
+    if (typeof window !== 'undefined') {
+      setPersistence(auth, browserLocalPersistence).catch((error) => {
+        console.error("Error setting Firebase persistence:", error);
+      });
+    }
     
     // Set a global flag to indicate we're NOT using mock authentication
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
- Added configuration to set Firebase authentication persistence to browserLocalPersistence, ensuring user sessions are maintained across page reloads.
- Included comments explaining the importance of using IndexedDB for production environments, particularly in privacy-focused browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now remain logged in across browser sessions, providing a seamless experience when returning to the app.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->