### PR TITLE
Fix public repo visibility detection

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@18.3.1)
+      psl:
+        specifier: ^1.9.0
+        version: 1.15.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -4536,6 +4539,9 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -10134,6 +10140,10 @@ snapshots:
       long: 5.3.1
 
   proxy-from-env@1.1.0: {}
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
 
   punycode@2.3.1: {}
 

--- a/services/BranchAndRepositoryService.ts
+++ b/services/BranchAndRepositoryService.ts
@@ -164,7 +164,11 @@ export default class BranchAndRepositoryService {
           }
         );
         return response.data;
-      } catch (error) {
+      } catch (error: any) {
+        // Preserve the original error so the caller can access status code and response data
+        if (axios.isAxiosError(error)) {
+          throw error;
+        }
         throw new Error("Error fetching Repository");
       }
     }


### PR DESCRIPTION
Problem:
Public repositories were incorrectly treated as private when backend GitHub auth was missing (401/403) or response formats varied.

Fix:
- Improved parsing of /check-public-repo response formats (boolean/string/object)
- Updated error handling to avoid assuming 401/403 means private repo
- Improved messaging for 404 (repo not found / not accessible)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved repository validation with enhanced error handling and distinct messages for non-existent repos, private repositories, and authentication/rate-limit issues during GitHub repository linking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->