### PR TITLE
feat: spec/plan UI updates, API alignment, Mermaid handling, regenerate

### DIFF
--- a/app/(main)/task/[taskId]/code/page.tsx
+++ b/app/(main)/task/[taskId]/code/page.tsx
@@ -859,7 +859,7 @@ export default function VerticalTaskExecution() {
       {
         role: "assistant",
         content:
-          "I've generated a granular specification for the AI Chat Metadata logging. Review the goals below before we proceed to implementation.",
+          "Your implementation plan is ready. Review the tasks below and tell me what you'd like to change—we'll get it right before we start building.",
       },
     ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/services/PlanService.ts
+++ b/services/PlanService.ts
@@ -1,18 +1,39 @@
 import axios from "axios";
 import getHeaders from "@/app/utils/headers.util";
 import { parseApiError } from "@/lib/utils";
-import { ProFeatureError } from "@/lib/hooks/useProFeatureError";
 import {
   PlanGenerationRequest,
   PlanSubmitResponse,
   PlanStatusResponse,
   PlanItemsResponse,
+  PlanChatRequest,
+  PlanChatResponse,
 } from "@/lib/types/spec";
 
 export default class PlanService {
   private static readonly BASE_URL = process.env.NEXT_PUBLIC_WORKFLOWS_URL;
   /** New API base: /api/v1/recipes */
   private static readonly API_BASE = `${this.BASE_URL}/api/v1/recipes`;
+
+  /**
+   * Regenerate plan for a recipe (reset to SPEC_READY and trigger new plan generation).
+   * POST /api/v1/recipes/{recipe_id}/plan/regenerate → 202 Accepted.
+   */
+  static async regeneratePlan(recipeId: string): Promise<PlanSubmitResponse> {
+    try {
+      const headers = await getHeaders();
+      const response = await axios.post<PlanSubmitResponse>(
+        `${this.API_BASE}/${recipeId}/plan/regenerate`,
+        {},
+        { headers },
+      );
+      return response.data;
+    } catch (error: any) {
+      console.error("[PlanService] Error regenerating plan:", error);
+      const errorMessage = parseApiError(error);
+      throw new Error(errorMessage);
+    }
+  }
 
   /**
    * Trigger plan generation for a recipe
@@ -38,17 +59,6 @@ export default class PlanService {
       return response.data;
     } catch (error: any) {
       console.error("Error submitting plan generation:", error);
-      
-      // Check for 404/500 status errors (backend exists but endpoint not available)
-      if (error?.response?.status === 404 || error?.response?.status === 500) {
-        throw new ProFeatureError("Build a feature is not available");
-      }
-      
-      // Check for network errors (CORS, connection refused, etc.) - backend not accessible
-      if (!error.response && (error?.code === 'ERR_NETWORK' || error?.code === 'ERR_FAILED' || error?.code === 'ECONNREFUSED')) {
-        throw new ProFeatureError("Build a feature is not available");
-      }
-      
       const errorMessage = parseApiError(error);
       throw new Error(errorMessage);
     }
@@ -91,6 +101,210 @@ export default class PlanService {
   static async getPlanStatusBySpecId(specId: string): Promise<PlanStatusResponse> {
     console.warn("[PlanService] getPlanStatusBySpecId is deprecated. The new API requires recipe_id.");
     throw new Error("getPlanStatusBySpecId is not supported in the new API. Use getPlanStatusByRecipeId instead.");
+  }
+
+  /**
+   * Start plan generation with SSE streaming.
+   * POST /api/v1/recipes/{recipe_id}/plan/generate-stream
+   * Returns run_id from X-Run-Id header; consumes stream and calls onEvent for each SSE event.
+   */
+  static async startPlanGenerationStream(
+    recipeId: string,
+    options: {
+      streamTokens?: boolean;
+      /** If false, only start the task and return runId without consuming the stream (e.g. for redirect to plan page). */
+      consumeStream?: boolean;
+      onEvent?: (eventType: string, data: Record<string, unknown>) => void;
+      onError?: (error: string) => void;
+      signal?: AbortSignal;
+    }
+  ): Promise<{ runId: string }> {
+    const headers = await getHeaders();
+    const url = `${this.API_BASE}/${recipeId}/plan/generate-stream${options.streamTokens !== false ? "?stream_tokens=true" : ""}`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { ...headers, Accept: "text/event-stream" },
+      credentials: "include",
+      signal: options.signal,
+    });
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(errText || `Plan stream failed: ${response.status}`);
+    }
+    let runId =
+      response.headers.get("X-Run-Id")?.trim() ||
+      response.headers.get("x-run-id")?.trim() ||
+      "";
+    if (!runId && response.body && (options.consumeStream === false || !options.onEvent)) {
+      try {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        for (let i = 0; i < 8; i++) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const dataMatch = buffer.match(/data:\s*(\{[^]*?\})\s*\n/);
+          if (dataMatch) {
+            const data = JSON.parse(dataMatch[1]) as Record<string, unknown>;
+            const fromData =
+              typeof data.run_id === "string"
+                ? data.run_id
+                : data.data && typeof (data.data as Record<string, unknown>).run_id === "string"
+                  ? (data.data as Record<string, unknown>).run_id
+                  : "";
+            if (fromData) runId = String(fromData).trim();
+            break;
+          }
+        }
+        reader.cancel();
+      } catch {
+        // ignore
+      }
+    }
+    if (options.consumeStream === false || !options.onEvent) {
+      return { runId };
+    }
+    const reader = response.body?.getReader();
+    const decoder = new TextDecoder();
+    if (reader && options.onEvent) {
+      (async () => {
+        let buffer = "";
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n\n");
+            buffer = lines.pop() || "";
+            for (const block of lines) {
+              if (!block.trim()) continue;
+              let eventType = "message";
+              let eventId: string | undefined;
+              let data: Record<string, unknown> = {};
+              for (const line of block.split("\n")) {
+                if (line.startsWith("event:")) eventType = line.replace(/^event:\s*/, "").trim();
+                if (line.startsWith("id:")) eventId = line.replace(/^id:\s*/, "").trim();
+                if (line.startsWith("data:")) {
+                  try {
+                    data = JSON.parse(line.replace(/^data:\s*/, "").trim()) as Record<string, unknown>;
+                  } catch {
+                    data = { raw: line.replace(/^data:\s*/, "").trim() };
+                  }
+                }
+              }
+              if (eventId) data.eventId = eventId;
+              options.onEvent?.(eventType, data);
+              if (eventType === "end" || eventType === "error") return;
+            }
+          }
+        } catch (e) {
+          options.onError?.(e instanceof Error ? e.message : String(e));
+        }
+      })();
+    }
+    return { runId };
+  }
+
+  /**
+   * Plan chat - send message to Plan Editor Agent
+   * POST /api/v1/recipes/{recipe_id}/edit?edit_type=plan
+   * Backend builds edit history from DB; we only send user_message.
+   */
+  static async planChat(
+    recipeId: string,
+    request: PlanChatRequest,
+  ): Promise<PlanChatResponse> {
+    try {
+      const headers = await getHeaders();
+      const response = await axios.post<{
+        edit_type: string;
+        intent: string;
+        plan_edits?: unknown[];
+        explanation: string;
+        spec_sync_required?: boolean;
+        spec_impact?: Record<string, unknown>;
+        updated_plan?: Record<string, unknown>;
+        task_id?: string;
+      }>(
+        `${this.API_BASE}/${recipeId}/edit?edit_type=plan`,
+        { user_message: request.message },
+        { headers },
+      );
+      const d = response.data;
+      return {
+        intent: d.intent ?? "clarify",
+        message: d.explanation,
+        explanation: d.explanation,
+        plan_output: d.updated_plan ?? null,
+        undo_token: "",
+        next_actions: [],
+      };
+    } catch (error: any) {
+      console.error("[PlanService] Plan chat error:", error);
+      const errorMessage = parseApiError(error);
+      throw new Error(errorMessage);
+    }
+  }
+
+  /**
+   * Reconnect to an existing plan stream.
+   * GET /api/v1/recipes/{recipe_id}/plan/stream?run_id=...&cursor=...
+   */
+  static connectPlanStream(
+    recipeId: string,
+    runId: string,
+    options: {
+      cursor?: string | null;
+      onEvent?: (eventType: string, data: Record<string, unknown>) => void;
+      onError?: (error: string) => void;
+      signal?: AbortSignal;
+    }
+  ): void {
+    const url = `${this.API_BASE}/${recipeId}/plan/stream?run_id=${encodeURIComponent(runId)}${options.cursor ? `&cursor=${encodeURIComponent(options.cursor)}` : ""}`;
+    getHeaders().then((headers) => {
+      fetch(url, {
+        method: "GET",
+        headers: { ...headers, Accept: "text/event-stream" },
+        credentials: "include",
+        signal: options.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) throw new Error(`Stream connect failed: ${response.status}`);
+          const reader = response.body?.getReader();
+          const decoder = new TextDecoder();
+          if (!reader || !options.onEvent) return;
+          let buffer = "";
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n\n");
+            buffer = lines.pop() || "";
+            for (const block of lines) {
+              if (!block.trim()) continue;
+              let eventType = "message";
+              let eventId: string | undefined;
+              let data: Record<string, unknown> = {};
+              for (const line of block.split("\n")) {
+                if (line.startsWith("event:")) eventType = line.replace(/^event:\s*/, "").trim();
+                if (line.startsWith("id:")) eventId = line.replace(/^id:\s*/, "").trim();
+                if (line.startsWith("data:")) {
+                  try {
+                    data = JSON.parse(line.replace(/^data:\s*/, "").trim()) as Record<string, unknown>;
+                  } catch {
+                    data = { raw: line.replace(/^data:\s*/, "").trim() };
+                  }
+                }
+              }
+              if (eventId) data.eventId = eventId;
+              options.onEvent?.(eventType, data);
+              if (eventType === "end" || eventType === "error") return;
+            }
+          }
+        })
+        .catch((e) => options.onError?.(e instanceof Error ? e.message : String(e)));
+    });
   }
 
   /**

--- a/services/SpecService.ts
+++ b/services/SpecService.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 import getHeaders from "@/app/utils/headers.util";
 import { parseApiError } from "@/lib/utils";
-import { throwIfProFeatureError } from "@/lib/hooks/useProFeatureError";
 import {
   SpecPlanRequest,
   SpecPlanSubmitResponse,
@@ -19,6 +18,8 @@ import {
   TriggerSpecGenerationResponse,
   SpecStatusResponse,
   RecipeDetailsResponse,
+  SpecChatRequest,
+  SpecChatResponse,
 } from "@/lib/types/spec";
 
 export default class SpecService {
@@ -127,9 +128,6 @@ export default class SpecService {
       return response.data;
     } catch (error: any) {
       console.error("[SpecService] Error creating recipe:", error);
-      
-      throwIfProFeatureError(error, "Build a feature is not available");
-      
       const errorMessage = parseApiError(error);
       throw new Error(errorMessage);
     }
@@ -155,9 +153,6 @@ export default class SpecService {
       return response.data;
     } catch (error: any) {
       console.error("[SpecService] Error triggering question generation:", error);
-      
-      throwIfProFeatureError(error, "Build a feature is not available");
-      
       const errorMessage = parseApiError(error);
       throw new Error(errorMessage);
     }
@@ -286,22 +281,240 @@ export default class SpecService {
   }
 
   /**
+   * Start spec generation with SSE streaming.
+   * POST /api/v1/recipes/{recipe_id}/spec/generate-stream
+   * Returns run_id from X-Run-Id header; consumes stream and calls onEvent for each SSE event.
+   */
+  static async startSpecGenerationStream(
+    recipeId: string,
+    options: {
+      streamTokens?: boolean;
+      /** If false, only start the task and return runId without consuming the stream (e.g. for redirect to spec page). */
+      consumeStream?: boolean;
+      onEvent?: (eventType: string, data: Record<string, unknown>) => void;
+      onError?: (error: string) => void;
+      signal?: AbortSignal;
+    }
+  ): Promise<{ runId: string }> {
+    const headers = await getHeaders();
+    const url = `${this.API_BASE}/${recipeId}/spec/generate-stream${options.streamTokens ? "?stream_tokens=true" : ""}`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { ...headers, Accept: "text/event-stream" },
+      credentials: "include",
+      signal: options.signal,
+    });
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(errText || `Spec stream failed: ${response.status}`);
+    }
+    // Prefer X-Run-Id (case-insensitive per HTTP); some proxies normalize to lowercase
+    let runId =
+      response.headers.get("X-Run-Id")?.trim() ||
+      response.headers.get("x-run-id")?.trim() ||
+      "";
+    // Fallback: some backends send run_id in the first SSE event instead of header
+    if (!runId && response.body && (options.consumeStream === false || !options.onEvent)) {
+      try {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        for (let i = 0; i < 8; i++) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          // Match data: {...} (single line) or multi-line JSON
+          const dataMatch = buffer.match(/data:\s*(\{[^]*?\})\s*\n/);
+          if (dataMatch) {
+            const data = JSON.parse(dataMatch[1]) as Record<string, unknown>;
+            const fromData =
+              typeof data.run_id === "string"
+                ? data.run_id
+                : data.data && typeof (data.data as Record<string, unknown>).run_id === "string"
+                  ? (data.data as Record<string, unknown>).run_id
+                  : "";
+            if (fromData) runId = String(fromData).trim();
+            break;
+          }
+        }
+        reader.cancel();
+      } catch {
+        // ignore parse errors
+      }
+    }
+    if (options.consumeStream === false || !options.onEvent) {
+      return { runId };
+    }
+    const reader = response.body?.getReader();
+    const decoder = new TextDecoder();
+    if (reader && options.onEvent) {
+      (async () => {
+        let buffer = "";
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n\n");
+            buffer = lines.pop() || "";
+            for (const block of lines) {
+              if (!block.trim()) continue;
+              let eventType = "message";
+              let eventId: string | undefined;
+              let data: Record<string, unknown> = {};
+              for (const line of block.split("\n")) {
+                if (line.startsWith("event:")) eventType = line.replace(/^event:\s*/, "").trim();
+                if (line.startsWith("id:")) eventId = line.replace(/^id:\s*/, "").trim();
+                if (line.startsWith("data:")) {
+                  try {
+                    data = JSON.parse(line.replace(/^data:\s*/, "").trim()) as Record<string, unknown>;
+                  } catch {
+                    data = { raw: line.replace(/^data:\s*/, "").trim() };
+                  }
+                }
+              }
+              if (eventId) data.eventId = eventId;
+              options.onEvent?.(eventType, data);
+              if (eventType === "end" || eventType === "error") return;
+            }
+          }
+        } catch (e) {
+          options.onError?.(e instanceof Error ? e.message : String(e));
+        }
+      })();
+    }
+    return { runId };
+  }
+
+  /**
+   * Reconnect to an existing spec stream (e.g. after page refresh).
+   * GET /api/v1/recipes/{recipe_id}/spec/stream?run_id=...&cursor=...
+   */
+  static connectSpecStream(
+    recipeId: string,
+    runId: string,
+    options: {
+      cursor?: string | null;
+      onEvent?: (eventType: string, data: Record<string, unknown>) => void;
+      onError?: (error: string) => void;
+      signal?: AbortSignal;
+    }
+  ): void {
+    const url = `${this.API_BASE}/${recipeId}/spec/stream?run_id=${encodeURIComponent(runId)}${options.cursor ? `&cursor=${encodeURIComponent(options.cursor)}` : ""}`;
+    getHeaders().then((headers) => {
+      fetch(url, {
+        method: "GET",
+        headers: { ...headers, Accept: "text/event-stream" },
+        credentials: "include",
+        signal: options.signal,
+      })
+        .then(async (response) => {
+          if (!response.ok) throw new Error(`Stream connect failed: ${response.status}`);
+          const reader = response.body?.getReader();
+          const decoder = new TextDecoder();
+          if (!reader || !options.onEvent) return;
+          let buffer = "";
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n\n");
+            buffer = lines.pop() || "";
+            for (const block of lines) {
+              if (!block.trim()) continue;
+              let eventType = "message";
+              let eventId: string | undefined;
+              let data: Record<string, unknown> = {};
+              for (const line of block.split("\n")) {
+                if (line.startsWith("event:")) eventType = line.replace(/^event:\s*/, "").trim();
+                if (line.startsWith("id:")) eventId = line.replace(/^id:\s*/, "").trim();
+                if (line.startsWith("data:")) {
+                  try {
+                    data = JSON.parse(line.replace(/^data:\s*/, "").trim()) as Record<string, unknown>;
+                  } catch {
+                    data = { raw: line.replace(/^data:\s*/, "").trim() };
+                  }
+                }
+              }
+              if (eventId) data.eventId = eventId;
+              options.onEvent?.(eventType, data);
+              if (eventType === "end" || eventType === "error") return;
+            }
+          }
+        })
+        .catch((e) => options.onError?.(e instanceof Error ? e.message : String(e)));
+    });
+  }
+
+  /**
+   * Spec chat - send message to Spec Editor Agent
+   * POST /api/v1/recipes/{recipe_id}/edit?edit_type=spec
+   * Backend builds edit history from DB; we only send user_message.
+   */
+  static async specChat(
+    recipeId: string,
+    request: SpecChatRequest,
+  ): Promise<SpecChatResponse> {
+    try {
+      const headers = await getHeaders();
+      const response = await axios.post<{
+        edit_type: string;
+        intent: string;
+        change_percentage?: number;
+        requires_regeneration?: boolean;
+        target_agent?: string;
+        updated_spec?: Record<string, unknown>;
+        explanation: string;
+        edits?: unknown[];
+        task_id?: string;
+      }>(
+        `${this.API_BASE}/${recipeId}/edit?edit_type=spec`,
+        { user_message: request.message },
+        { headers },
+      );
+      const d = response.data;
+      return {
+        intent: (d.intent ?? "clarify") as SpecChatResponse["intent"],
+        message: d.explanation,
+        explanation: d.explanation,
+        spec_output: (d.updated_spec ?? { add: [], modify: [], fix: [] }) as SpecChatResponse["spec_output"],
+        undo_token: "",
+        next_actions: [],
+        regenerate_triggered: d.requires_regeneration ?? false,
+      };
+    } catch (error: any) {
+      console.error("[SpecService] Spec chat error:", error);
+      const errorMessage = parseApiError(error);
+      throw new Error(errorMessage);
+    }
+  }
+
+  /**
    * Get comprehensive recipe details including repo and branch information
    * GET /api/v1/recipes/{recipe_id}/details
+   * On 404 returns a minimal response so callers can use localStorage/fallbacks instead of throwing.
    */
   static async getRecipeDetails(
     recipeId: string,
   ): Promise<RecipeDetailsResponse> {
     try {
-      console.log("[SpecService] Fetching recipe details for:", recipeId);
       const headers = await getHeaders();
       const response = await axios.get<RecipeDetailsResponse>(
         `${this.API_BASE}/${recipeId}/details`,
         { headers },
       );
-      console.log("[SpecService] Recipe details response:", response.data);
       return response.data;
     } catch (error: any) {
+      if (error?.response?.status === 404) {
+        return {
+          recipe_id: recipeId,
+          project_id: "",
+          user_prompt: "Implementation plan generation",
+          repo_name: null,
+          branch_name: null,
+          questions_and_answers: [],
+        };
+      }
       console.error("[SpecService] Error fetching recipe details:", error);
       const errorMessage = parseApiError(error);
       throw new Error(errorMessage);


### PR DESCRIPTION
- SpecService/PlanService: use edit endpoints (/{recipe_id}/edit?edit_type=spec|plan) and map response fields (updated_spec→spec_output, plan_output, etc.)
- Spec/Plan/Code pages: updated default assistant messages
- View full output: changed to icon-only Maximize2 button with tooltip
- MermaidDiagram: add looksLikeMermaid() guard to avoid rendering diffs/code
- Plan page: phase name in right panel header, info icon left of phase name
- Plan page: wire regenerate plan button (PlanService.regeneratePlan)
- Plan page: architecture fallback to raw text when not Mermaid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live streaming output during spec and plan generation with real-time progress tracking
  * Chat interactions within spec and plan editors for collaborative feedback
  * Plan regeneration capability with visual status indicators
  * Live output modal to review full generated content

* **Improvements**
  * Enhanced Mermaid diagram rendering with improved fallback handling for unsupported formats
  * More collaborative onboarding messaging in plan generation workflow
  * Streamlined navigation flow from plans to code implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->