### PR TITLE
fix: suppress toasts on stream abort (spec + plan regenerate)

### DIFF
--- a/app/(main)/task/[taskId]/plan/page.tsx
+++ b/app/(main)/task/[taskId]/plan/page.tsx
@@ -510,6 +510,8 @@ const PlanPage = () => {
           }
         },
         onError: async (msg) => {
+          // Don't treat abort as an error - expected when switching streams or regenerating
+          if (/abort/i.test(msg)) return;
           // On stream error, check if plan is already completed - if so, don't show error toast
           try {
             const fallbackStatus = await PlanService.getPlanStatusByRecipeId(recipeId);

--- a/app/(main)/task/[taskId]/spec/page.tsx
+++ b/app/(main)/task/[taskId]/spec/page.tsx
@@ -876,6 +876,8 @@ const SpecPage = () => {
           }
         },
         onError: async (msg) => {
+          // Don't treat abort as an error - expected when switching streams or regenerating
+          if (/abort/i.test(msg)) return;
           // On stream error, check if spec is already completed - if so, don't show error toast
           try {
             const fallbackStatus = await SpecService.getSpecProgressByRecipeId(recipeId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling to correctly recognize expected stream aborts as normal operations rather than errors. Users will no longer see error messages when switching between streams or regenerating content. This prevents unnecessary error notifications and provides a smoother, more seamless experience during these common actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->