### PR TITLE
fixed public repo placeholder

### DIFF
--- a/app/(main)/idea/components/IdeaInputCard.tsx
+++ b/app/(main)/idea/components/IdeaInputCard.tsx
@@ -1040,14 +1040,12 @@ export default function IdeaInputCard({
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle>Enter Public Repository</DialogTitle>
-            <DialogDescription>
-              Enter a GitHub repository URL or <code>owner/repo</code> format (e.g., <code>https://github.com/facebook/react</code> or <code>facebook/react</code>)
-            </DialogDescription>
+            
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
               <Input
-                placeholder="GitHub URL or owner/repo (e.g., https://github.com/facebook/react)"
+                placeholder="e.g. owner/repo or https://github.com/owner/repo"
                 value={publicRepoInput}
                 onChange={(e) => setPublicRepoInput(e.target.value)}
                 onKeyDown={(e) => {


### PR DESCRIPTION
before:
<img width="610" height="430" alt="Screenshot 2026-02-19 at 1 18 37 PM" src="https://github.com/user-attachments/assets/995b0dec-b0d6-424d-bb0e-7d236028d285" />

after:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Public Repository input field placeholder text with clearer format examples to improve user guidance on acceptable input formats.
  * Simplified the repository section dialog layout for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->