### PR TITLE
api keys can be saved

### DIFF
--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -136,6 +136,8 @@ const [openRouterInput, setOpenRouterInput] = useState("");
 
   const savedProvider =
     (keySecrets?.inference_config?.provider ?? keySecrets?.chat_config?.provider)?.toLowerCase();
+  const savedApiKey =
+    keySecrets?.inference_config?.api_key ?? keySecrets?.chat_config?.api_key;
 
   return (
     <div className="p-6 w-full min-w-0 overflow-hidden">
@@ -225,7 +227,7 @@ const [openRouterInput, setOpenRouterInput] = useState("");
                 <Input
                   type="password"
                   className="flex-1 bg-white text-sm"
-                  placeholder={savedProvider === "openai" && keySecrets?.inference_config?.api_key ? maskedKey(keySecrets.inference_config.api_key) : ""}
+                  placeholder={savedProvider === "openai" && savedApiKey ? maskedKey(savedApiKey) : ""}
                   value={openAIInput}
                   onChange={(e) => setOpenAIInput(e.target.value)}
                 />
@@ -248,7 +250,7 @@ const [openRouterInput, setOpenRouterInput] = useState("");
                 <Input
                   type="password"
                   className="flex-1 bg-white text-sm"
-                  placeholder={savedProvider === "anthropic" && keySecrets?.inference_config?.api_key ? maskedKey(keySecrets.inference_config.api_key) : ""}
+                  placeholder={savedProvider === "anthropic" && savedApiKey ? maskedKey(savedApiKey) : ""}
                   value={anthropicInput}
                   onChange={(e) => setAnthropicInput(e.target.value)}
                 />
@@ -271,7 +273,7 @@ const [openRouterInput, setOpenRouterInput] = useState("");
                 <Input
                   type="password"
                   className="flex-1 bg-white text-sm"
-                  placeholder={savedProvider === "openrouter" && keySecrets?.inference_config?.api_key ? maskedKey(keySecrets.inference_config.api_key) : ""}
+                  placeholder={savedProvider === "openrouter" && savedApiKey ? maskedKey(savedApiKey) : ""}
                   value={openRouterInput}
                   onChange={(e) => setOpenRouterInput(e.target.value)}
                 />


### PR DESCRIPTION
backend schema requires { api_key, model } where model must be in "provider/model_name" format. updated frontend to send in that format.

<img width="1470" height="956" alt="Screenshot 2026-02-22 at 12 10 34 PM" src="https://github.com/user-attachments/assets/78d1ed65-26f8-4c7d-bf09-bf719cd47bf9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page now manages separate chat and inference provider configurations, integration keys, and automatically selects a sensible model when saving a provider key.

* **Bug Fixes**
  * More robust null-safe handling and display of API keys and secrets; settings now gracefully handles missing secrets (404) and falls back to available config values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->