### PR TITLE
added 4 switch tabs to switch between qna, spec, plan and codegen

### DIFF
--- a/app/(main)/all-chats/page.tsx
+++ b/app/(main)/all-chats/page.tsx
@@ -21,7 +21,8 @@ import { toast } from "@/components/ui/sonner";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { LucideEdit, LucideTrash } from "lucide-react";
 import ChatService from "@/services/ChatService";
-import RecipeService from "@/services/RecipeService"; 
+import RecipeService from "@/services/RecipeService";
+import { getRecipeRedirectUrl } from "@/lib/utils/recipeRedirect";
 
 const AllChats = () => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -85,47 +86,6 @@ const AllChats = () => {
 
   const handleChatClick = (chat: any) => {
     dispatch(setChat({ agentId: chat.agent_id, temporaryContext: { branch: chat.branch, repo: chat.repository, projectId: chat.project_ids[0] }, selectedNodes: [], title: chat.title, chatFlow: "EXISTING_CHAT" }));
-  };
-
-  // Get redirect URL for recipe based on status
-  const getRecipeRedirectUrl = (recipe: any): string => {
-    const recipeId = recipe.id || recipe.recipe_id;
-    const status = (recipe.status || '').toUpperCase();
-    
-    // Check if status contains "QUESTIONS" (e.g., PENDING_QUESTIONS, QUESTIONS_READY)
-    // This matches patterns like "QUESTIONS*" as requested
-    if (status.includes('QUESTIONS')) {
-      const params = new URLSearchParams();
-      if (recipe.project_id) {
-        params.set('projectId', recipe.project_id);
-      }
-      if (recipeId) {
-        params.set('recipeId', recipeId);
-      }
-      return `/repo?${params.toString()}`;
-    }
-    
-    // Check if status contains "SPEC" (e.g., SPEC_IN_PROGRESS, SPEC_READY, ANSWERS_SUBMITTED)
-    // This matches patterns like "SPEC*" as requested
-    if (status.includes('SPEC') || status === 'ANSWERS_SUBMITTED') {
-      return `/task/${recipeId}/spec`;
-    }
-    
-    // Check if status contains "PLAN" (e.g., PLAN_IN_PROGRESS, PLAN_READY)
-    // This matches patterns like "PLAN*" as requested
-    if (status.includes('PLAN')) {
-      return `/task/${recipeId}/plan`;
-    }
-    
-    // Default: redirect to repo page for questions (for initial states)
-    const params = new URLSearchParams();
-    if (recipe.project_id) {
-      params.set('projectId', recipe.project_id);
-    }
-    if (recipeId) {
-      params.set('recipeId', recipeId);
-    }
-    return `/repo?${params.toString()}`;
   };
 
   // Combine chats and recipes into a single list

--- a/app/(main)/task/[taskId]/code/page.tsx
+++ b/app/(main)/task/[taskId]/code/page.tsx
@@ -84,7 +84,10 @@ import {
   type StreamTimelineItem,
 } from "@/components/stream/StreamTimeline";
 import { BuildFlowChatHeader } from "@/components/build-flow/BuildFlowChatHeader";
-import { persistCodegenQueryString } from "@/lib/buildFlow";
+import {
+  markCodegenStartedForRecipe,
+  persistCodegenQueryString,
+} from "@/lib/buildFlow";
 
 /** sessionStorage key for codegen thinking */
 const THINKING_STORAGE_KEY_CODEGEN = "potpie_thinking_codegen";
@@ -857,6 +860,13 @@ export default function VerticalTaskExecution() {
   const [taskSplittingId, setTaskSplittingId] = useState<string | null>(
     taskSplittingIdFromUrl || null,
   );
+
+  useEffect(() => {
+    if (recipeId && taskSplittingId) {
+      markCodegenStartedForRecipe(recipeId);
+    }
+  }, [recipeId, taskSplittingId]);
+
   const [taskSplittingStatus, setTaskSplittingStatus] =
     useState<TaskSplittingStatusResponse | null>(null);
   const [allLayers, setAllLayers] = useState<TaskLayer[]>([]);

--- a/app/(main)/task/[taskId]/code/page.tsx
+++ b/app/(main)/task/[taskId]/code/page.tsx
@@ -18,7 +18,6 @@ import {
   Loader2,
   Code2,
   ShieldCheck,
-  GitBranch,
   Maximize2,
   CheckCircle2,
   Circle,
@@ -37,8 +36,6 @@ import {
   ExternalLink,
   Hourglass,
   List,
-  ArrowLeft,
-  Github,
   Sparkles,
   Info,
   RefreshCw,
@@ -86,6 +83,8 @@ import {
   StreamTimeline,
   type StreamTimelineItem,
 } from "@/components/stream/StreamTimeline";
+import { BuildFlowChatHeader } from "@/components/build-flow/BuildFlowChatHeader";
+import { persistCodegenQueryString } from "@/lib/buildFlow";
 
 /** sessionStorage key for codegen thinking */
 const THINKING_STORAGE_KEY_CODEGEN = "potpie_thinking_codegen";
@@ -810,6 +809,14 @@ export default function VerticalTaskExecution() {
   const taskSplittingIdFromUrl = searchParams.get("taskSplittingId");
   const repoNameFromUrl = searchParams.get("repoName");
 
+  // Keep last codegen query (slice + task splitting id) for build-flow tab navigation
+  useEffect(() => {
+    if (!recipeId) return;
+    const qs = searchParams.toString();
+    if (!qs) return;
+    persistCodegenQueryString(recipeId, `?${qs}`);
+  }, [recipeId, searchParams]);
+
   const repoBranchByTask = useSelector(
     (state: RootState) => state.RepoAndBranch.byTaskId,
   );
@@ -1099,6 +1106,26 @@ export default function VerticalTaskExecution() {
   const displayRepoName =
     repoNameFromUrl || storedRepoContext?.repoName || repoName;
   const displayBranchName = storedRepoContext?.branchName || branchName;
+
+  /** Title for build-flow header: avoid blank h1 while prompt loads; prefer localStorage recipe cache */
+  const codePageHeaderTitle = useMemo(() => {
+    const trimmed = recipePrompt?.trim();
+    if (trimmed) {
+      return `${trimmed.slice(0, 50)}${trimmed.length > 50 ? "…" : ""}`;
+    }
+    if (typeof window !== "undefined" && recipeId) {
+      try {
+        const raw = localStorage.getItem(`recipe_${recipeId}`);
+        if (raw) {
+          const u = (JSON.parse(raw) as { user_prompt?: string }).user_prompt?.trim();
+          if (u) return `${u.slice(0, 50)}${u.length > 50 ? "…" : ""}`;
+        }
+      } catch {
+        // ignore
+      }
+    }
+    return "Code generation";
+  }, [recipePrompt, recipeId]);
 
   // Initialize the left "chat" with the prompt + a codegen helper message (once per recipe).
   // Run once per recipeId; use fallback prompt if recipePrompt not loaded yet so the pane is never empty.
@@ -2165,10 +2192,20 @@ export default function VerticalTaskExecution() {
   // Show loading if we don't have planId yet (plan items loading)
   if (!planId && isLoadingPlanItems) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center">
-          <Loader2 className="w-8 h-8 animate-spin mx-auto mb-4 text-primary-color" />
-          <p className="text-primary-color">Loading task data...</p>
+      <div className="flex h-screen min-h-0 flex-col overflow-hidden bg-background text-primary-color font-sans selection:bg-zinc-100 antialiased">
+        <div className="shrink-0 border-b border-[#E5E8E6] bg-[#FAF8F7] px-6 pt-4 pb-3">
+          <BuildFlowChatHeader
+            recipeId={recipeId}
+            title={codePageHeaderTitle}
+            repoName={displayRepoName}
+            branchName={displayBranchName}
+          />
+        </div>
+        <div className="flex min-h-0 flex-1 items-center justify-center">
+          <div className="text-center">
+            <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-primary-color" />
+            <p className="text-primary-color">Loading task data...</p>
+          </div>
         </div>
       </div>
     );
@@ -2186,19 +2223,6 @@ export default function VerticalTaskExecution() {
   //     </div>
   //   );
   // }
-
-  const Badge = ({
-    children,
-    icon: Icon,
-  }: {
-    children: React.ReactNode;
-    icon?: React.ComponentType<{ className?: string }>;
-  }) => (
-    <div className="flex items-center gap-1.5 px-2 py-0.5 border border-[#D3E5E5] rounded text-xs font-medium text-primary-color bg-white">
-      {Icon && <Icon className="w-3.5 h-3.5" />}
-      <span className="truncate">{children}</span>
-    </div>
-  );
 
   const handleSendChatMessage = async () => {
     const text = chatInput.trim();
@@ -2277,21 +2301,18 @@ export default function VerticalTaskExecution() {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-background text-primary-color font-sans selection:bg-zinc-100 antialiased">
-      <div className="flex-1 flex min-h-0 overflow-hidden">
-        {/* Left: Chat + plan */}
-        <div className="flex-[1] flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-[#D3E5E5] bg-[#FAF8F7]">
-          {/* Header */}
-          <div className="flex justify-between items-center px-6 py-4 shrink-0">
-            <h1 className="text-lg font-bold text-primary-color truncate capitalize">
-              {recipePrompt?.slice(0, 50) ?? "Chat Name"}
-              {(recipePrompt?.length ?? 0) > 50 ? "…" : ""}
-            </h1>
-            <div className="flex items-center gap-2 shrink-0">
-              <Badge icon={Github}>{displayRepoName}</Badge>
-              <Badge icon={GitBranch}>{displayBranchName}</Badge>
-            </div>
-          </div>
+      <div className="shrink-0 border-b border-[#E5E8E6] bg-[#FAF8F7] px-6 pt-4 pb-3">
+        <BuildFlowChatHeader
+          recipeId={recipeId}
+          title={codePageHeaderTitle}
+          repoName={displayRepoName}
+          branchName={displayBranchName}
+        />
+      </div>
 
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {/* Left: Chat + plan */}
+        <div className="flex-[1] flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-[#E5E8E6] bg-[#FAF8F7]">
           {/* Messages */}
           <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-4">
             {chatMessages.map((msg, i) => (
@@ -2658,8 +2679,8 @@ export default function VerticalTaskExecution() {
 
         {/* Right: Code generation */}
         <div className="overflow-hidden flex-none flex flex-col w-1/2 min-w-0">
-          <aside className="h-full w-full min-w-[320px] flex flex-col border-l border-[#D3E5E5]">
-            <div className="p-6 border-b border-[#D3E5E5] bg-white">
+          <aside className="h-full w-full min-w-[320px] flex flex-col border-l border-[#E5E8E6]">
+            <div className="p-6 border-b border-[#E5E8E6] bg-white">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2 min-w-0">
                   <h2
@@ -2687,7 +2708,7 @@ export default function VerticalTaskExecution() {
                         setSelectedChangedFilePath(null);
                         setChangedFilesSliderOpen(true);
                       }}
-                      className="shrink-0 px-4 py-2 rounded-lg font-semibold text-xs flex items-center gap-2 border border-[#D3E5E5] bg-white text-[#022019] hover:bg-[#F5F5F5] transition-colors"
+                      className="shrink-0 px-4 py-2 rounded-lg font-semibold text-xs flex items-center gap-2 border border-[#E5E8E6] bg-white text-[#022019] hover:bg-[#F5F5F5] transition-colors"
                       title="View all files and diffs"
                     >
                       View files
@@ -2701,7 +2722,7 @@ export default function VerticalTaskExecution() {
                       <button
                         type="button"
                         onClick={handleDownloadCode}
-                        className="shrink-0 px-4 py-2 rounded-lg font-semibold text-xs flex items-center gap-2 border border-[#D3E5E5] bg-white text-[#022019] hover:bg-[#F5F5F5] transition-colors"
+                        className="shrink-0 px-4 py-2 rounded-lg font-semibold text-xs flex items-center gap-2 border border-[#E5E8E6] bg-white text-[#022019] hover:bg-[#F5F5F5] transition-colors"
                         title="Download generated code as zip"
                       >
                         <Download className="w-3.5 h-3.5" />
@@ -2878,7 +2899,7 @@ export default function VerticalTaskExecution() {
 
             {/* Sticky Create PR / View PR at end of code gen panel */}
             {taskSplittingId && (
-              <div className="sticky bottom-0 shrink-0 border-t border-[#D3E5E5] bg-white px-6 py-4 flex justify-end">
+              <div className="sticky bottom-0 shrink-0 border-t border-[#E5E8E6] bg-white px-6 py-4 flex justify-end">
                 {taskSplittingStatus?.pr_url ? (
                   <a
                     href={taskSplittingStatus.pr_url}

--- a/app/(main)/task/[taskId]/plan/page.tsx
+++ b/app/(main)/task/[taskId]/plan/page.tsx
@@ -64,7 +64,12 @@ import { SharedMarkdown } from "@/components/chat/SharedMarkdown";
 import { useNavigationProgress } from "@/contexts/NavigationProgressContext";
 import { getStreamEventPayload, normalizeMarkdownForPreview } from "@/lib/utils";
 import { downloadPlanAsMarkdown } from "@/lib/utils/markdownExport";
-import { markCodegenStartedForRecipe } from "@/lib/buildFlow";
+import {
+  CODEGEN_STARTED_EVENT,
+  hasCodegenStartedForRecipe,
+  hasImplementationBeenStartedBefore,
+  markCodegenStartedForRecipe,
+} from "@/lib/buildFlow";
 import {
   StreamTimeline,
   type StreamTimelineItem,
@@ -386,6 +391,33 @@ const PlanPage = () => {
           return (data?.generation_status === "processing" || data?.generation_status === "pending") ? 2000 : false;
         },
   });
+
+  const { data: recipeDetailsForImplBtn } = useQuery({
+    queryKey: ["recipe-details", recipeId, "plan-start-impl-label"],
+    queryFn: () => SpecService.getRecipeDetails(recipeId),
+    enabled: !!recipeId,
+    staleTime: 10_000,
+  });
+
+  const [sessionCodegenFlag, setSessionCodegenFlag] = useState(false);
+
+  useEffect(() => {
+    setSessionCodegenFlag(hasCodegenStartedForRecipe(recipeId));
+  }, [recipeId]);
+
+  useEffect(() => {
+    const onMarked = (e: Event) => {
+      const d = (e as CustomEvent<{ recipeId?: string }>).detail;
+      if (d?.recipeId === recipeId) setSessionCodegenFlag(true);
+    };
+    window.addEventListener(CODEGEN_STARTED_EVENT, onMarked);
+    return () => window.removeEventListener(CODEGEN_STARTED_EVENT, onMarked);
+  }, [recipeId]);
+
+  const showReStartImplementation = hasImplementationBeenStartedBefore(
+    recipeDetailsForImplBtn?.status,
+    sessionCodegenFlag,
+  );
 
   useEffect(() => {
     if (statusData) {
@@ -1354,7 +1386,9 @@ const PlanPage = () => {
                 }}
                 className="px-6 py-2.5 rounded-lg font-medium text-sm bg-[#022019] text-[#B4D13F] hover:opacity-90 shadow-sm"
               >
-                START IMPLEMENTATION
+                {showReStartImplementation
+                  ? "RE-START IMPLEMENTATION"
+                  : "START IMPLEMENTATION"}
               </button>
             </div>
           )}

--- a/app/(main)/task/[taskId]/plan/page.tsx
+++ b/app/(main)/task/[taskId]/plan/page.tsx
@@ -23,8 +23,6 @@ import {
   AlignLeft,
   ListTodo,
   AlertCircle,
-  Github,
-  GitBranch,
   LucideIcon,
   FileText,
   Lightbulb,
@@ -34,7 +32,6 @@ import {
   SendHorizonal,
   RotateCw,
   Wrench,
-  ArrowLeft,
   Download,
 } from "lucide-react";
 import {
@@ -71,6 +68,7 @@ import {
   StreamTimeline,
   type StreamTimelineItem,
 } from "@/components/stream/StreamTimeline";
+import { BuildFlowChatHeader } from "@/components/build-flow/BuildFlowChatHeader";
 
 /**
  * VERTICAL SLICE PLANNER (Auto-Generation Mode)
@@ -206,21 +204,6 @@ const getModuleIcon = (name: string) => {
     default: return Code2;
   }
 };
-
-const HeaderBadge = ({ children, icon: Icon }: { children: React.ReactNode; icon?: LucideIcon }) => (
-  <div className="flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium" style={{ border: "1px solid #CCD3CF", color: "#022019" }}>
-    {Icon && <Icon className="w-3.5 h-3.5" />}
-    {children}
-  </div>
-);
-
-/** Chat pill badge (matches spec page) */
-const ChatBadge = ({ children, icon: Icon }: { children: React.ReactNode; icon?: LucideIcon }) => (
-  <div className="flex items-center gap-1.5 px-2 py-0.5 border border-[#D3E5E5] rounded text-xs font-medium text-[#022019]">
-    {Icon && <Icon className="w-3.5 h-3.5" />}
-    {children}
-  </div>
-);
 
 const FormattedText = ({ text }: { text: string }) => {
   if (!text) return null;
@@ -685,33 +668,21 @@ const PlanPage = () => {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-[#FAF8F7] text-[#000000] font-sans antialiased">
-      <div className="flex-1 flex min-h-0 overflow-hidden">
-        {/* Left: Chat (same pattern as spec page) */}
-        <div className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-[#D3E5E5] bg-[#FAF8F7] chat-panel-contained">
-          <div className="px-6 pt-4 pb-2 shrink-0 flex flex-col gap-2">
-            <button
-              type="button"
-              onClick={() => {
-                if (!recipeId) return;
-                router.push(`/task/${recipeId}/spec`);
-              }}
-              className="inline-flex items-center gap-1 text-xs font-medium text-[#022019] px-0 py-0.5 rounded-md hover:underline w-fit"
-            >
-              <ArrowLeft className="w-3 h-3" />
-              Back to spec
-            </button>
-            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-              <h1 className="text-lg font-bold text-[#022019] truncate capitalize">
-                {userPrompt?.slice(0, 50) || "Chat Name"}
-                {(userPrompt?.length ?? 0) > 50 ? "…" : ""}
-              </h1>
-              <div className="flex items-center gap-2 shrink-0 mt-1 sm:mt-0">
-                <ChatBadge icon={Github}>{displayRepoName}</ChatBadge>
-                <ChatBadge icon={GitBranch}>{displayBranchName}</ChatBadge>
-              </div>
-            </div>
-          </div>
+      <div className="shrink-0 border-b border-[#E5E8E6] bg-[#FAF8F7] px-6 pt-4 pb-3">
+        <BuildFlowChatHeader
+          recipeId={recipeId}
+          variant="plan"
+          title={`${userPrompt?.slice(0, 50) || "Chat Name"}${
+            (userPrompt?.length ?? 0) > 50 ? "…" : ""
+          }`}
+          repoName={displayRepoName}
+          branchName={displayBranchName}
+        />
+      </div>
 
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {/* Left: Chat (same pattern as spec page) */}
+        <div className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-[#E5E8E6] bg-[#FAF8F7] chat-panel-contained">
           <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-6 py-4 space-y-4">
             {chatMessages.map((msg, i) => (
               <React.Fragment key={i}>
@@ -874,8 +845,8 @@ const PlanPage = () => {
         </div>
 
         {/* Right: Phase Plan panel (top bar matches Spec page) */}
-        <aside className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 border-l border-[#D3E5E5]">
-          <div className="p-6 border-b border-[#D3E5E5] bg-[#FFFDFC] shrink-0">
+        <aside className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 border-l border-[#E5E8E6]">
+          <div className="p-6 border-b border-[#E5E8E6] bg-[#FFFDFC] shrink-0">
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-2">
               <h2 className="text-[18px] font-bold leading-tight tracking-tight shrink-0 truncate min-w-0" style={{ color: "#022019" }} title={`Phase ${selectedPhaseIndex + 1}`}>
@@ -1010,7 +981,7 @@ const PlanPage = () => {
                   {phase.name}
                 </h3>
                 <Tabs defaultValue="summary" className="w-full">
-                  <TabsList className="w-full grid grid-cols-3 rounded-none border-b border-[#D3E5E5] bg-[#F7F6F5] p-0 h-11 gap-0">
+                  <TabsList className="w-full grid grid-cols-3 rounded-none border-b border-[#E5E8E6] bg-[#F7F6F5] p-0 h-11 gap-0">
                     <TabsTrigger
                       value="summary"
                       className="rounded-none h-11 px-0 text-sm font-medium text-[#022019] border-b-2 border-transparent shadow-none data-[state=active]:bg-[#EAF4C8] data-[state=active]:border-[#B4D13F]"
@@ -1354,7 +1325,7 @@ const PlanPage = () => {
           </div>
 
           {isCompleted && planItems.length > 0 && (
-            <div className="shrink-0 p-6 pt-4 border-t border-[#D3E5E5] bg-[#FFFDFC] flex justify-end">
+            <div className="shrink-0 p-6 pt-4 border-t border-[#E5E8E6] bg-[#FFFDFC] flex justify-end">
               <button
                 type="button"
                 onClick={async () => {

--- a/app/(main)/task/[taskId]/plan/page.tsx
+++ b/app/(main)/task/[taskId]/plan/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useCallback, useState, useEffect, useRef, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { MermaidDiagram, looksLikeMermaid } from "@/components/chat/MermaidDiagram";
 import {
@@ -66,6 +66,7 @@ import { getStreamEventPayload, normalizeMarkdownForPreview } from "@/lib/utils"
 import { downloadPlanAsMarkdown } from "@/lib/utils/markdownExport";
 import {
   CODEGEN_STARTED_EVENT,
+  buildFlowNavRecipeDetailsQueryKey,
   hasCodegenStartedForRecipe,
   hasImplementationBeenStartedBefore,
   markCodegenStartedForRecipe,
@@ -250,6 +251,14 @@ const PlanPage = () => {
   const runIdFromUrl = searchParams.get("run_id");
   const repoNameFromUrl = searchParams.get("repoName");
 
+  const invalidatePlanStatusAndBuildFlowNav = useCallback(() => {
+    if (!recipeId) return;
+    queryClient.invalidateQueries({ queryKey: ["plan-status", recipeId] });
+    queryClient.invalidateQueries({
+      queryKey: buildFlowNavRecipeDetailsQueryKey(recipeId),
+    });
+  }, [queryClient, recipeId]);
+
   const repoBranchByTask = useSelector((state: RootState) => state.RepoAndBranch.byTaskId);
   const storedRepoContext = recipeId ? repoBranchByTask?.[recipeId] : undefined;
 
@@ -282,7 +291,7 @@ const PlanPage = () => {
 
   const bottomRef = useRef<HTMLDivElement>(null);
   const planContentRef = useRef<HTMLDivElement>(null);
-  const { startNavigation } = useNavigationProgress();
+  const { startNavigation, endNavigation } = useNavigationProgress();
 
   useEffect(() => {
     const fetchRecipeDetails = async () => {
@@ -458,7 +467,7 @@ const PlanPage = () => {
         if (genStatus === "completed" || genStatus === "failed") {
           // Plan is already done, no need to stream - just update state and clear run_id from URL
           setPlanStatus(currentStatus);
-          queryClient.invalidateQueries({ queryKey: ["plan-status", recipeId] });
+          invalidatePlanStatusAndBuildFlowNav();
           router.replace(`/task/${recipeId}/plan`, { scroll: false });
           return;
         }
@@ -532,14 +541,14 @@ const PlanPage = () => {
           }
           if (eventType === "end") {
             setStreamProgress(null);
-            queryClient.invalidateQueries({ queryKey: ["plan-status", recipeId] });
+            invalidatePlanStatusAndBuildFlowNav();
             PlanService.getPlanStatusByRecipeId(recipeId).then(setPlanStatus).catch(() => {});
             router.replace(`/task/${recipeId}/plan`, { scroll: false });
           }
           if (eventType === "error") {
             setStreamProgress(null);
             setStreamItems([]);
-            queryClient.invalidateQueries({ queryKey: ["plan-status", recipeId] });
+            invalidatePlanStatusAndBuildFlowNav();
             PlanService.getPlanStatusByRecipeId(recipeId).then(setPlanStatus).catch(() => {});
             router.replace(`/task/${recipeId}/plan`, { scroll: false });
           }
@@ -552,7 +561,7 @@ const PlanPage = () => {
             const fallbackStatus = await PlanService.getPlanStatusByRecipeId(recipeId);
             const genStatus = fallbackStatus.generation_status;
             setPlanStatus(fallbackStatus);
-            queryClient.invalidateQueries({ queryKey: ["plan-status", recipeId] });
+            invalidatePlanStatusAndBuildFlowNav();
             if (genStatus === "completed" || genStatus === "failed") {
               // Plan finished, stream just wasn't available - no error to show
               setStreamProgress(null);
@@ -576,7 +585,7 @@ const PlanPage = () => {
       cancelled = true;
       streamAbortRef.current?.abort();
     };
-  }, [recipeId, runIdFromUrl, queryClient, router]);
+  }, [recipeId, runIdFromUrl, router, invalidatePlanStatusAndBuildFlowNav]);
 
   // Auto-scroll to end when stream items change
   useEffect(() => {
@@ -593,9 +602,9 @@ const PlanPage = () => {
 
     hasTriggeredPlanGenRef.current = true;
     PlanService.submitPlanGeneration({ recipe_id: recipeId })
-      .then(() => queryClient.invalidateQueries({ queryKey: ["plan-status", recipeId] }))
+      .then(() => invalidatePlanStatusAndBuildFlowNav())
       .catch(() => {});
-  }, [recipeId, isLoadingStatus, statusData, runIdFromUrl, queryClient]);
+  }, [recipeId, isLoadingStatus, statusData, runIdFromUrl, invalidatePlanStatusAndBuildFlowNav]);
 
   // Extract plan items from phases (new API)
   useEffect(() => {
@@ -919,7 +928,7 @@ const PlanPage = () => {
                         await PlanService.regeneratePlan(recipeId);
                         toast.success("Plan regeneration started");
                         setPlanStatus(null);
-                        queryClient.invalidateQueries({ queryKey: ["plan-status", recipeId] });
+                        invalidatePlanStatusAndBuildFlowNav();
                       } catch (err: any) {
                         console.error("Error regenerating plan:", err);
                         toast.error(err?.message ?? "Failed to regenerate plan");
@@ -1378,10 +1387,7 @@ const PlanPage = () => {
                   } catch (e) {
                     console.error("Failed to start implementation", e);
                     toast.error("Failed to start implementation");
-                    markCodegenStartedForRecipe(recipeId);
-                    router.push(
-                      `/task/${recipeId}/code?planId=${planId}&itemNumber=${firstItem.item_number}`
-                    );
+                    endNavigation();
                   }
                 }}
                 className="px-6 py-2.5 rounded-lg font-medium text-sm bg-[#022019] text-[#B4D13F] hover:opacity-90 shadow-sm"

--- a/app/(main)/task/[taskId]/plan/page.tsx
+++ b/app/(main)/task/[taskId]/plan/page.tsx
@@ -64,6 +64,7 @@ import { SharedMarkdown } from "@/components/chat/SharedMarkdown";
 import { useNavigationProgress } from "@/contexts/NavigationProgressContext";
 import { getStreamEventPayload, normalizeMarkdownForPreview } from "@/lib/utils";
 import { downloadPlanAsMarkdown } from "@/lib/utils/markdownExport";
+import { markCodegenStartedForRecipe } from "@/lib/buildFlow";
 import {
   StreamTimeline,
   type StreamTimelineItem,
@@ -1336,6 +1337,7 @@ const PlanPage = () => {
                       recipe_id: recipeId,
                       plan_item_id: firstItem.id,
                     });
+                    markCodegenStartedForRecipe(recipeId);
                     const params = new URLSearchParams();
                     params.set("planId", planId);
                     params.set("itemNumber", String(firstItem.item_number));
@@ -1344,6 +1346,7 @@ const PlanPage = () => {
                   } catch (e) {
                     console.error("Failed to start implementation", e);
                     toast.error("Failed to start implementation");
+                    markCodegenStartedForRecipe(recipeId);
                     router.push(
                       `/task/${recipeId}/code?planId=${planId}&itemNumber=${firstItem.item_number}`
                     );

--- a/app/(main)/task/[taskId]/qna/components/AdditionalContextSection.tsx
+++ b/app/(main)/task/[taskId]/qna/components/AdditionalContextSection.tsx
@@ -13,6 +13,8 @@ interface AdditionalContextSectionProps {
   onGeneratePlan: () => void;
   isGenerating: boolean;
   recipeId: string | null;
+  /** When spec (next step) has already been generated once — show "Re-generate" label. */
+  reGenerateImplementationPlan?: boolean;
   unansweredCount?: number;
   /** Called when attached files change. removedIndex set when user removes file at that index. */
   onAttachmentChange?: (files: File[], removedIndex?: number) => void;
@@ -37,6 +39,7 @@ export default function AdditionalContextSection({
   onGeneratePlan,
   isGenerating,
   recipeId,
+  reGenerateImplementationPlan = false,
   unansweredCount: _unansweredCount,
   onAttachmentChange,
   attachmentUploading = false,
@@ -183,6 +186,8 @@ export default function AdditionalContextSection({
                   <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
                   GENERATING...
                 </>
+              ) : reGenerateImplementationPlan ? (
+                "RE-GENERATE IMPLEMENTATION PLAN"
               ) : (
                 "GENERATE IMPLEMENTATION PLAN"
               )}

--- a/app/(main)/task/[taskId]/qna/page.tsx
+++ b/app/(main)/task/[taskId]/qna/page.tsx
@@ -39,6 +39,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { BuildFlowChatHeader } from "@/components/build-flow/BuildFlowChatHeader";
+import { hasSpecBeenCompletedOnce } from "@/lib/buildFlow";
 import {
   RecipeQuestionsResponse,
   RecipeQuestion,
@@ -157,6 +158,16 @@ export default function QnaPage() {
     questionGenerationStatus: null,
     questionGenerationError: null,
   });
+
+  const { data: recipeDetailsForGenerateLabel } = useQuery({
+    queryKey: ["recipe-details", recipeId, "qna-generate-label"],
+    queryFn: () => SpecService.getRecipeDetails(recipeId!),
+    enabled: !!recipeId,
+    staleTime: 10_000,
+  });
+  const reGenerateImplementationPlan = hasSpecBeenCompletedOnce(
+    recipeDetailsForGenerateLabel?.status,
+  );
 
   // Fetch recipe details when recipeId is available (same priority as spec: API then localStorage)
   useEffect(() => {
@@ -1909,6 +1920,7 @@ export default function QnaPage() {
                 onGeneratePlan={handleGeneratePlan}
                 isGenerating={state.isGenerating}
                 recipeId={recipeId}
+                reGenerateImplementationPlan={reGenerateImplementationPlan}
                 onAttachmentChange={handleAttachmentChange}
                 attachmentUploading={state.attachmentUploading}
               />

--- a/app/(main)/task/[taskId]/qna/page.tsx
+++ b/app/(main)/task/[taskId]/qna/page.tsx
@@ -34,12 +34,11 @@ import {
   Check,
   ChevronDown,
   FileText,
-  Github,
-  GitBranch,
   Info,
   Loader2,
   Wrench,
 } from "lucide-react";
+import { BuildFlowChatHeader } from "@/components/build-flow/BuildFlowChatHeader";
 import {
   RecipeQuestionsResponse,
   RecipeQuestion,
@@ -75,19 +74,6 @@ function getSortedSections(sectionKeys: Iterable<string>): string[] {
     return a.localeCompare(b);
   });
 }
-
-const Badge = ({
-  children,
-  icon: Icon,
-}: {
-  children: React.ReactNode;
-  icon?: React.ComponentType<{ className?: string }>;
-}) => (
-  <div className="flex items-center gap-1.5 px-2 py-0.5 border border-border-light rounded text-xs font-medium text-primary-color">
-    {Icon && <Icon className="w-3.5 h-3.5" />}
-    {children}
-  </div>
-);
 
 const RECIPE_ID_UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -1794,20 +1780,24 @@ export default function QnaPage() {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-background text-primary-color font-sans antialiased">
-      <div className="flex-1 flex min-h-0 overflow-hidden">
+      <div className="shrink-0 border-b border-[#E5E8E6] bg-[#FAF8F7] px-6 pt-4 pb-3">
+        <BuildFlowChatHeader
+          recipeId={recipeId}
+          title={`${featureIdea?.slice(0, 50) || "Clarifying Questions"}${
+            (featureIdea?.length ?? 0) > 50 ? "…" : ""
+          }`}
+          repoName={repoName || "Unknown Repository"}
+          branchName={branchName || "main"}
+        />
+      </div>
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left: questions area — same structure as spec chat */}
         {/* Full width when no questions, half width when questions ready */}
         <div
           className={`flex flex-col min-w-0 min-h-0 overflow-hidden transition-all duration-300 ${hasQuestionsReady ? 'flex-1' : 'w-full'}`}
           style={{ backgroundColor: "#FAF8F7" }}
         >
-          {/* Title on left side */}
-          <div className="shrink-0 px-6 pt-6 pb-4">
-            <h1 className="text-lg font-bold text-primary-color truncate capitalize min-w-0">
-              {featureIdea?.slice(0, 50) || "Clarifying Questions"}
-              {(featureIdea?.length ?? 0) > 50 ? "…" : ""}
-            </h1>
-          </div>
           <div
             className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-6 py-4 space-y-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             style={{ msOverflowStyle: "none" }}
@@ -1934,14 +1924,7 @@ export default function QnaPage() {
             className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden"
             style={{ backgroundColor: "#FAF8F7" }}
           >
-            {/* Repo/branch badges on right side */}
-            <div className="flex justify-end items-center px-6 pt-6 pb-4 shrink-0 gap-2">
-              {repoName && repoName !== "Unknown Repository" && (
-                <Badge icon={Github}>{repoName}</Badge>
-              )}
-              {branchName && <Badge icon={GitBranch}>{branchName}</Badge>}
-            </div>
-            <aside className="flex-1 min-h-0 w-full min-w-[280px] flex flex-col overflow-hidden">
+            <aside className="flex-1 min-h-0 w-full min-w-[280px] flex flex-col overflow-hidden pt-6">
               <div className="flex-1 overflow-y-auto min-h-0 py-3 pl-6 pr-8">
                 <h2 className="text-sm font-bold mb-2 text-left text-primary-color">
                   Clarifying Questions

--- a/app/(main)/task/[taskId]/spec/page.tsx
+++ b/app/(main)/task/[taskId]/spec/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   Check,
@@ -999,6 +1000,20 @@ const SpecPage = () => {
   const { plan: normalizedPlan, rawSpec: rawSpecification } = normalizeSpecFromProgress(specProgress ?? undefined);
   const hasSpecContent = normalizedPlan !== null || rawSpecification !== null;
 
+  const { data: planStatusForLabel } = useQuery({
+    queryKey: ["plan-status", recipeId],
+    queryFn: () => PlanService.getPlanStatusByRecipeId(recipeId!),
+    enabled:
+      !!recipeId &&
+      status === "COMPLETED" &&
+      !isCancelled &&
+      hasSpecContent,
+    staleTime: 30_000,
+  });
+  const planGenForLabel = planStatusForLabel?.generation_status?.toLowerCase();
+  const showReGeneratePlanButton =
+    planGenForLabel === "completed" || planGenForLabel === "failed";
+
   // Persist stream timeline when spec is completed so it survives refresh
   useEffect(() => {
     if (!recipeId || status !== "COMPLETED" || !hasSpecContent) return;
@@ -1396,7 +1411,7 @@ const SpecPage = () => {
                   disabled={isGeneratingPlan}
                   className="shrink-0 px-6 py-2 rounded-lg font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 bg-primary text-primary-foreground hover:opacity-90"
                 >
-                  GENERATE PLAN
+                  {showReGeneratePlanButton ? "RE-GENERATE PLAN" : "GENERATE PLAN"}
                 </button>
               </div>
             )}

--- a/app/(main)/task/[taskId]/spec/page.tsx
+++ b/app/(main)/task/[taskId]/spec/page.tsx
@@ -3,8 +3,6 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
-  Github,
-  GitBranch,
   Check,
   Loader2,
   ChevronDown,
@@ -23,7 +21,6 @@ import {
   RotateCcw,
   RotateCw,
   Wrench,
-  ArrowLeft,
   Download,
 } from "lucide-react";
 import SpecService from "@/services/SpecService";
@@ -62,6 +59,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import Image from "next/image";
+import { BuildFlowChatHeader } from "@/components/build-flow/BuildFlowChatHeader";
 
 interface FileItem {
   path: string;
@@ -373,13 +371,6 @@ function SpecFallbackView({ spec }: { spec: SpecificationOutput }) {
     </div>
   );
 }
-
-const Badge = ({ children, icon: Icon }: { children: React.ReactNode; icon?: React.ComponentType<{ className?: string }> }) => (
-  <div className="flex items-center gap-1.5 px-2 py-0.5 border border-[#E5E8E6] rounded text-xs font-medium text-primary-color">
-    {Icon && <Icon className="w-3.5 h-3.5" />}
-    {children}
-  </div>
-);
 
 const PlanTabs = ({ plan }: { plan: Plan }) => {
   // Combine all items from all categories
@@ -1112,38 +1103,28 @@ const SpecPage = () => {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-background text-primary-color font-sans selection:bg-zinc-100 antialiased">
-      <div className="flex-1 flex min-h-0 overflow-hidden">
+      {/* Full-width build flow bar — tabs extend to the right edge */}
+      <div className="shrink-0 border-b border-[#E5E8E6] bg-[#FAF8F7] px-6 pt-4 pb-3">
+        <BuildFlowChatHeader
+          recipeId={recipeId}
+          title={`${recipeData?.user_prompt?.slice(0, 50) || "Chat Name"}${
+            (recipeData?.user_prompt?.length ?? 0) > 50 ? "…" : ""
+          }`}
+          repoName={
+            repoNameFromUrl ||
+            storedRepoContext?.repoName ||
+            projectData?.repo ||
+            "Unknown Repository"
+          }
+          branchName={
+            storedRepoContext?.branchName || projectData?.branch || "main"
+          }
+        />
+      </div>
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left: Chat area — fixed height so only messages scroll; input always visible */}
         <div className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-r-[1px] border-[#E5E8E6] bg-[#FAF8F7] chat-panel-contained">
-          {/* Chat header */}
-          <div className="px-6 pt-4 pb-2 shrink-0 flex flex-col gap-2">
-            <button
-              type="button"
-              onClick={() => {
-                if (!recipeId) return;
-                router.push(`/task/${recipeId}/qna`);
-              }}
-              className="inline-flex items-center gap-1 text-xs font-medium text-primary-color px-0 py-0.5 rounded-md hover:underline w-fit"
-            >
-              <ArrowLeft className="w-3 h-3" />
-              Back to questions
-            </button>
-            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-              <h1 className="text-lg font-bold text-primary-color truncate capitalize">
-                {recipeData?.user_prompt?.slice(0, 50) || "Chat Name"}
-                {(recipeData?.user_prompt?.length ?? 0) > 50 ? "…" : ""}
-              </h1>
-              <div className="flex items-center gap-2 shrink-0 mt-1 sm:mt-0">
-                <Badge icon={Github}>
-                  {repoNameFromUrl || storedRepoContext?.repoName || projectData?.repo || "Unknown Repository"}
-                </Badge>
-                <Badge icon={GitBranch}>
-                  {storedRepoContext?.branchName || projectData?.branch || "main"}
-                </Badge>
-              </div>
-            </div>
-          </div>
-
           {/* Messages — only this section scrolls */}
           <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-6 py-4 space-y-4">
             {chatMessages.map((msg, i) => (

--- a/components/Layouts/ChatHistoryPanel.tsx
+++ b/components/Layouts/ChatHistoryPanel.tsx
@@ -31,6 +31,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import ChatService from "@/services/ChatService";
+import RecipeService from "@/services/RecipeService";
+import { getRecipeRedirectUrl } from "@/lib/utils/recipeRedirect";
 import { setChat } from "@/lib/state/Reducers/chat";
 import { AppDispatch } from "@/lib/state/store";
 import { Visibility } from "@/lib/Constants";
@@ -142,69 +144,104 @@ export function ChatHistoryPanel() {
     };
   }, [searchTerm]);
 
-  // Fetch chats
+  // Fetch chats (same source as /all-chats)
   const { data: chats, isLoading } = useQuery<Chat[]>({
     queryKey: ["sidebar-chats"],
     queryFn: () => ChatService.getAllChats(),
     staleTime: 60000, // 1 minute
   });
 
-  // Filter and sort chats
-  const filteredChats = useMemo(() => {
-    if (!chats) return [];
+  const { data: recipes = [], isLoading: recipesLoading } = useQuery({
+    queryKey: ["all-recipes"],
+    queryFn: () => RecipeService.getAllRecipes(0, 100),
+    staleTime: 60000,
+    retry: false,
+  });
 
-    // Get all pinned chats that aren't builds
-    const pinnedChatList = chats.filter((chat) => {
-      const chatRecipeId = (chat as any).recipe_id || (chat as any).recipeId;
-      return !chatRecipeId && pinnedChats.has(chat.id);
-    });
+  // Merge chats + build flows (recipes) like /all-chats — skip conversations tied to a recipe to avoid duplicates
+  const allItems = useMemo(() => {
+    const items: any[] = [];
 
-    // Get filtered non-pinned chats (excluding builds)
-    const nonPinnedChats = chats.filter((chat) => {
-      const chatRecipeId = (chat as any).recipe_id || (chat as any).recipeId;
-      if (chatRecipeId) return false;
-      if (pinnedChats.has(chat.id)) return false;
+    if (Array.isArray(chats) && chats.length > 0) {
+      chats.forEach((chat: any) => {
+        const chatRecipeId = chat.recipe_id || chat.recipeId;
+        if (chatRecipeId) return;
+        items.push({ ...chat, type: "chat" });
+      });
+    }
 
-      if (!debouncedSearchTerm) return true;
-      const searchLower = debouncedSearchTerm.toLowerCase();
+    if (Array.isArray(recipes) && recipes.length > 0) {
+      recipes.forEach((recipe: any) => {
+        const id = recipe.id || recipe.recipe_id;
+        items.push({
+          ...recipe,
+          id,
+          type: "recipe",
+          title: recipe.user_prompt,
+          repository: recipe.repo_name,
+          branch: recipe.branch_name,
+          project_id: recipe.project_id,
+        });
+      });
+    }
+
+    return items;
+  }, [chats, recipes]);
+
+  const filteredItems = useMemo(() => {
+    if (!debouncedSearchTerm) return allItems;
+
+    const searchLower = debouncedSearchTerm.toLowerCase();
+    return allItems.filter((item: any) => {
+      const title = item.title?.toLowerCase() || "";
+      const repository = (item.repository || "").toLowerCase();
+      const branch = (item.branch || "").toLowerCase();
+      const agentId = (item.agent_id || "").toLowerCase();
+      const status = (item.status || "").toLowerCase();
+
       return (
-        chat.title?.toLowerCase().includes(searchLower) ||
-        chat.repository?.toLowerCase().includes(searchLower) ||
-        chat.branch?.toLowerCase().includes(searchLower) ||
-        chat.agent_id?.toLowerCase().includes(searchLower)
+        title.includes(searchLower) ||
+        repository.includes(searchLower) ||
+        branch.includes(searchLower) ||
+        agentId.includes(searchLower) ||
+        status.includes(searchLower)
       );
     });
+  }, [allItems, debouncedSearchTerm]);
 
-    // Sort pinned chats by created_at descending
-    const sortedPinned = pinnedChatList.sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  // Pinned chats first (builds are not pinned), then everything else by recency
+  const orderedItems = useMemo(() => {
+    const pinned = filteredItems.filter(
+      (item: any) => item.type === "chat" && pinnedChats.has(item.id)
     );
-
-    // Sort non-pinned chats by created_at descending
-    const sortedNonPinned = nonPinnedChats.sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    const unpinned = filteredItems.filter(
+      (item: any) => !(item.type === "chat" && pinnedChats.has(item.id))
     );
+    const sortByCreated = (a: any, b: any) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    return [...[...pinned].sort(sortByCreated), ...[...unpinned].sort(sortByCreated)];
+  }, [filteredItems, pinnedChats]);
 
-    // Combine: pinned first, then filtered non-pinned
-    return [...sortedPinned, ...sortedNonPinned];
-  }, [chats, debouncedSearchTerm, pinnedChats]);
-
-  const handleChatClick = useCallback(
-    (chat: Chat) => {
+  const handleItemClick = useCallback(
+    (item: any) => {
+      if (item.type === "recipe") {
+        router.push(getRecipeRedirectUrl(item));
+        return;
+      }
       dispatch(
         setChat({
-          agentId: chat.agent_id || "",
+          agentId: item.agent_id || "",
           temporaryContext: {
-            branch: chat.branch || "",
-            repo: chat.repository || "",
-            projectId: chat.project_ids?.[0] || "",
+            branch: item.branch || "",
+            repo: item.repository || "",
+            projectId: item.project_ids?.[0] || "",
           },
           selectedNodes: [],
-          title: chat.title,
+          title: item.title,
           chatFlow: "EXISTING_CHAT",
         })
       );
-      router.push(`/chat/${chat.id}`);
+      router.push(`/chat/${item.id}`);
     },
     [dispatch, router]
   );
@@ -440,7 +477,7 @@ export function ChatHistoryPanel() {
       {/* Header with Search Icon */}
       <div className="px-6 py-2 flex items-center justify-between">
         <h3 className="text-xs font-medium text-zinc-500 uppercase tracking-wider" style={{ fontFamily: 'Uncut Sans, sans-serif' }}>
-          Your Chats
+          Chats & builds
         </h3>
         <Button
           variant="ghost"
@@ -461,7 +498,7 @@ export function ChatHistoryPanel() {
       {showSearchInput && (
         <div className="px-6 pb-2">
           <Input
-            placeholder="Search chats..."
+            placeholder="Search chats and builds..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="h-8 text-xs bg-white border-zinc-200"
@@ -473,33 +510,35 @@ export function ChatHistoryPanel() {
       {/* Chat List */}
       <ScrollArea className="h-[360px] px-4">
         <div className="space-y-0.5 pb-2">
-          {isLoading ? (
+          {isLoading || recipesLoading ? (
             // Loading skeletons
             Array.from({ length: 5 }).map((_, i) => (
               <div key={i} className="px-2 py-1.5">
                 <Skeleton className="h-5 w-full" />
               </div>
             ))
-          ) : filteredChats.length === 0 ? (
+          ) : orderedItems.length === 0 ? (
             <div className="px-4 py-4 text-center">
               <p className="text-xs text-muted-foreground">
                 {debouncedSearchTerm
-                  ? "No chats found"
-                  : "No chats yet"}
+                  ? "No chats or builds found"
+                  : "No chats or builds yet"}
               </p>
             </div>
           ) : (
-            filteredChats.map((chat) => {
-              const isPinned = pinnedChats.has(chat.id);
-              const isActive = isActiveChat(chat.id);
-              const isHovered = hoveredChatId === chat.id;
-              const isDropdownOpen = openDropdownId === chat.id;
+            orderedItems.map((item: any) => {
+              const rowKey = item.type === "recipe" ? `recipe-${item.id}` : item.id;
+              const isRecipe = item.type === "recipe";
+              const isPinned = !isRecipe && pinnedChats.has(item.id);
+              const isActive = !isRecipe && isActiveChat(item.id);
+              const isHovered = hoveredChatId === rowKey;
+              const isDropdownOpen = openDropdownId === rowKey;
 
               return (
                 <div
-                  key={chat.id}
-                  onClick={() => handleChatClick(chat)}
-                  onMouseEnter={() => setHoveredChatId(chat.id)}
+                  key={rowKey}
+                  onClick={() => handleItemClick(item)}
+                  onMouseEnter={() => setHoveredChatId(rowKey)}
                   onMouseLeave={() => setHoveredChatId(null)}
                   className={cn(
                     "group flex items-center justify-between px-2 py-1.5 rounded-md cursor-pointer text-sm transition-colors",
@@ -509,8 +548,16 @@ export function ChatHistoryPanel() {
                   )}
                 >
                   <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
+                    {isRecipe && (
+                      <span
+                        className="shrink-0 rounded px-1 py-0.5 text-[0.65rem] font-semibold bg-blue-100 text-blue-900"
+                        title="Build flow"
+                      >
+                        Build
+                      </span>
+                    )}
                     <span className="truncate text-sm block max-w-[160px]" style={{ fontFamily: 'Uncut Sans, sans-serif' }}>
-                      {chat.title || "Untitled Chat"}
+                      {item.title || (isRecipe ? "Untitled build" : "Untitled Chat")}
                     </span>
                     {isPinned && (
                       <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-primary">
@@ -520,103 +567,104 @@ export function ChatHistoryPanel() {
                     )}
                   </div>
 
-                  {/* 3-dots menu button - visible on hover or when dropdown is open */}
-                  <div
-                    className={cn(
-                      "relative shrink-0 transition-opacity duration-150",
-                      (isHovered || isDropdownOpen) ? "opacity-100" : "opacity-0"
-                    )}
-                  >
-                    <DropdownMenu
-                      open={isDropdownOpen}
-                      onOpenChange={(open) => setOpenDropdownId(open ? chat.id : null)}
+                  {!isRecipe && (
+                    <div
+                      className={cn(
+                        "relative shrink-0 transition-opacity duration-150",
+                        (isHovered || isDropdownOpen) ? "opacity-100" : "opacity-0"
+                      )}
                     >
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-6 w-6"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        side="right"
-                        align="start"
-                        className="w-40 bg-[#FFFFFF] border-[#E6E8E9]"
+                      <DropdownMenu
+                        open={isDropdownOpen}
+                        onOpenChange={(open) => setOpenDropdownId(open ? rowKey : null)}
                       >
-                        <DropdownMenuItem
-                          onClick={(e) => openShareDialog(chat, e)}
-                          className="focus:bg-[#F4F4F4] cursor-pointer"
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          side="right"
+                          align="start"
+                          className="w-40 bg-[#FFFFFF] border-[#E6E8E9]"
                         >
-                          <Image
-                            src="/images/share-03.svg"
-                            alt="Share"
-                            width={16}
-                            height={16}
-                            className="mr-2"
-                          />
-                          <span>Share</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={(e) => openRenameDialog(chat, e)}
-                          className="focus:bg-[#F4F4F4] cursor-pointer"
-                        >
-                          <Image
-                            src="/images/pen-01.svg"
-                            alt="Rename"
-                            width={16}
-                            height={16}
-                            className="mr-2"
-                          />
-                          <span>Rename</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={(e) => handlePinChat(chat.id, e)}
-                          className="focus:bg-[#F4F4F4] cursor-pointer"
-                        >
-                          {isPinned ? (
-                            <>
-                              <Image
-                                src="/images/unpin.svg"
-                                alt="Unpin"
-                                width={16}
-                                height={16}
-                                className="mr-2"
-                              />
-                              <span>Unpin Chat</span>
-                            </>
-                          ) : (
-                            <>
-                              <Image
-                                src="/images/pin.svg"
-                                alt="Pin"
-                                width={16}
-                                height={16}
-                                className="mr-2"
-                              />
-                              <span>Pin Chat</span>
-                            </>
-                          )}
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator className="bg-[#E6E8E9]" />
-                        <DropdownMenuItem
-                          onClick={(e) => openDeleteDialog(chat, e)}
-                          className="text-red-600 focus:text-red-600 focus:bg-[#F4F4F4] cursor-pointer"
-                        >
-                          <Image
-                            src="/images/delete-02.svg"
-                            alt="Delete"
-                            width={16}
-                            height={16}
-                            className="mr-2"
-                          />
-                          <span>Delete Chat</span>
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
+                          <DropdownMenuItem
+                            onClick={(e) => openShareDialog(item as Chat, e)}
+                            className="focus:bg-[#F4F4F4] cursor-pointer"
+                          >
+                            <Image
+                              src="/images/share-03.svg"
+                              alt="Share"
+                              width={16}
+                              height={16}
+                              className="mr-2"
+                            />
+                            <span>Share</span>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={(e) => openRenameDialog(item as Chat, e)}
+                            className="focus:bg-[#F4F4F4] cursor-pointer"
+                          >
+                            <Image
+                              src="/images/pen-01.svg"
+                              alt="Rename"
+                              width={16}
+                              height={16}
+                              className="mr-2"
+                            />
+                            <span>Rename</span>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={(e) => handlePinChat(item.id, e)}
+                            className="focus:bg-[#F4F4F4] cursor-pointer"
+                          >
+                            {isPinned ? (
+                              <>
+                                <Image
+                                  src="/images/unpin.svg"
+                                  alt="Unpin"
+                                  width={16}
+                                  height={16}
+                                  className="mr-2"
+                                />
+                                <span>Unpin Chat</span>
+                              </>
+                            ) : (
+                              <>
+                                <Image
+                                  src="/images/pin.svg"
+                                  alt="Pin"
+                                  width={16}
+                                  height={16}
+                                  className="mr-2"
+                                />
+                                <span>Pin Chat</span>
+                              </>
+                            )}
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator className="bg-[#E6E8E9]" />
+                          <DropdownMenuItem
+                            onClick={(e) => openDeleteDialog(item as Chat, e)}
+                            className="text-red-600 focus:text-red-600 focus:bg-[#F4F4F4] cursor-pointer"
+                          >
+                            <Image
+                              src="/images/delete-02.svg"
+                              alt="Delete"
+                              width={16}
+                              height={16}
+                              className="mr-2"
+                            />
+                            <span>Delete Chat</span>
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  )}
                 </div>
               );
             })

--- a/components/build-flow/BuildFlowChatHeader.tsx
+++ b/components/build-flow/BuildFlowChatHeader.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Github, GitBranch } from "lucide-react";
+import { BuildFlowStepNav } from "./BuildFlowStepNav";
+import { cn } from "@/lib/utils";
+
+type BuildFlowChatHeaderProps = {
+  recipeId: string;
+  title: string;
+  repoName: string;
+  branchName: string;
+  className?: string;
+  /** Plan page uses a darker title color to match existing layout */
+  variant?: "default" | "plan";
+};
+
+export function BuildFlowChatHeader({
+  recipeId,
+  title,
+  repoName,
+  branchName,
+  className,
+  variant = "default",
+}: BuildFlowChatHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex w-full min-w-0 flex-row items-center justify-between gap-4",
+        className
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <h1
+          className={cn(
+            "text-lg font-bold truncate capitalize",
+            variant === "plan" ? "text-[#022019]" : "text-primary-color"
+          )}
+        >
+          {title}
+        </h1>
+        <div className="mt-1.5 flex flex-row flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[#506561]">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <Github className="h-3.5 w-3.5 shrink-0 opacity-80" aria-hidden />
+            <span className="truncate">{repoName || "Unknown Repository"}</span>
+          </span>
+          <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+            <GitBranch className="h-3.5 w-3.5 shrink-0 opacity-80" aria-hidden />
+            <span className="truncate">{branchName || "main"}</span>
+          </span>
+        </div>
+      </div>
+      <BuildFlowStepNav
+        recipeId={recipeId}
+        className="ml-auto shrink-0 overflow-x-auto pb-0.5 [scrollbar-width:thin]"
+      />
+    </div>
+  );
+}

--- a/components/build-flow/BuildFlowStepNav.tsx
+++ b/components/build-flow/BuildFlowStepNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import SpecService from "@/services/SpecService";
@@ -7,11 +8,13 @@ import {
   BUILD_FLOW_STEPS,
   buildFlowStepFromPathname,
   canNavigateToBuildFlowStep,
+  CODEGEN_STARTED_EVENT,
   computeMaxReachableStepIndex,
+  getCodegenHrefForRecipe,
+  hasCodegenStartedForRecipe,
   type BuildFlowStep,
 } from "@/lib/buildFlow";
 import { cn } from "@/lib/utils";
-import { getCodegenHrefForRecipe } from "@/lib/buildFlow";
 
 type BuildFlowStepNavProps = {
   recipeId: string;
@@ -30,7 +33,24 @@ export function BuildFlowStepNav({ recipeId, className }: BuildFlowStepNavProps)
   });
 
   const recipeStatus = recipeDetails?.status ?? null;
-  const maxReachableIndex = computeMaxReachableStepIndex(recipeStatus, pathname);
+  const baseMaxReachable = computeMaxReachableStepIndex(recipeStatus, pathname);
+  const [codegenStarted, setCodegenStarted] = useState(false);
+
+  useEffect(() => {
+    const read = () => setCodegenStarted(hasCodegenStartedForRecipe(recipeId));
+    read();
+    const onMarked = (e: Event) => {
+      const detail = (e as CustomEvent<{ recipeId?: string }>).detail;
+      if (detail?.recipeId === recipeId) read();
+    };
+    window.addEventListener(CODEGEN_STARTED_EVENT, onMarked);
+    return () => window.removeEventListener(CODEGEN_STARTED_EVENT, onMarked);
+  }, [recipeId, pathname]);
+
+  const maxReachableIndex = Math.max(
+    baseMaxReachable,
+    codegenStarted ? 3 : 0,
+  );
   const activeStep = buildFlowStepFromPathname(pathname);
 
   const go = (step: BuildFlowStep, href: string) => {
@@ -69,7 +89,9 @@ export function BuildFlowStepNav({ recipeId, className }: BuildFlowStepNavProps)
               disabled={!enabled}
               title={
                 !enabled
-                  ? "Complete the current step to unlock this stage"
+                  ? step.id === "code"
+                    ? "Use “Start implementation” on the Plan page to begin codegen"
+                    : "Complete the current step to unlock this stage"
                   : undefined
               }
               onClick={() => go(step.id, href)}

--- a/components/build-flow/BuildFlowStepNav.tsx
+++ b/components/build-flow/BuildFlowStepNav.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import SpecService from "@/services/SpecService";
+import {
+  BUILD_FLOW_STEPS,
+  buildFlowStepFromPathname,
+  canNavigateToBuildFlowStep,
+  computeMaxReachableStepIndex,
+  type BuildFlowStep,
+} from "@/lib/buildFlow";
+import { cn } from "@/lib/utils";
+import { getCodegenHrefForRecipe } from "@/lib/buildFlow";
+
+type BuildFlowStepNavProps = {
+  recipeId: string;
+  className?: string;
+};
+
+export function BuildFlowStepNav({ recipeId, className }: BuildFlowStepNavProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const { data: recipeDetails } = useQuery({
+    queryKey: ["recipe-details", recipeId, "build-flow-nav"],
+    queryFn: () => SpecService.getRecipeDetails(recipeId),
+    enabled: Boolean(recipeId),
+    staleTime: 10_000,
+  });
+
+  const recipeStatus = recipeDetails?.status ?? null;
+  const maxReachableIndex = computeMaxReachableStepIndex(recipeStatus, pathname);
+  const activeStep = buildFlowStepFromPathname(pathname);
+
+  const go = (step: BuildFlowStep, href: string) => {
+    if (!canNavigateToBuildFlowStep(step, activeStep, maxReachableIndex)) return;
+    if (step === activeStep) return;
+    router.push(step === "code" ? getCodegenHrefForRecipe(recipeId) : href);
+  };
+
+  return (
+    <nav
+      className={cn(
+        "font-uncut flex h-[34px] w-[min(194px,100%)] max-w-full shrink-0 items-center gap-0 rounded-[8px] bg-[#F5F5F5] px-1 py-0",
+        className
+      )}
+      aria-label="Build flow"
+    >
+      {BUILD_FLOW_STEPS.map((step) => {
+        const enabled = canNavigateToBuildFlowStep(
+          step.id,
+          activeStep,
+          maxReachableIndex
+        );
+        const isActive = step.id === activeStep;
+        const href =
+          step.id === "code"
+            ? getCodegenHrefForRecipe(recipeId)
+            : `/task/${recipeId}${step.path}`;
+
+        return (
+          <div
+            key={step.id}
+            className="flex h-full min-w-0 flex-1 items-center justify-center"
+          >
+            <button
+              type="button"
+              disabled={!enabled}
+              title={
+                !enabled
+                  ? "Complete the current step to unlock this stage"
+                  : undefined
+              }
+              onClick={() => go(step.id, href)}
+              className={cn(
+                "relative flex items-center justify-center whitespace-nowrap text-center font-semibold leading-none tracking-tight transition-all duration-200",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#022019]/25 focus-visible:ring-offset-2 focus-visible:ring-offset-[#F5F5F5]",
+                isActive
+                  ? "box-border h-[23px] w-[49px] max-w-full -translate-y-px rounded-[7px] bg-[#FFFFFF] px-0.5 text-[10px] text-[#022019] shadow-[0_1px_2px_#00000026]"
+                  : "h-full min-h-0 w-full rounded-md px-1 py-0 text-xs",
+                !isActive &&
+                  enabled &&
+                  "text-[#5C6663] hover:text-[#022019]",
+                !isActive &&
+                  !enabled &&
+                  "cursor-not-allowed text-zinc-400",
+              )}
+            >
+              {step.label}
+            </button>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/build-flow/BuildFlowStepNav.tsx
+++ b/components/build-flow/BuildFlowStepNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { type FC, useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import SpecService from "@/services/SpecService";
@@ -9,6 +9,7 @@ import {
   buildFlowStepFromPathname,
   canNavigateToBuildFlowStep,
   CODEGEN_STARTED_EVENT,
+  buildFlowNavRecipeDetailsQueryKey,
   computeMaxReachableStepIndex,
   getCodegenHrefForRecipe,
   hasCodegenStartedForRecipe,
@@ -21,12 +22,15 @@ type BuildFlowStepNavProps = {
   className?: string;
 };
 
-export function BuildFlowStepNav({ recipeId, className }: BuildFlowStepNavProps) {
+export const BuildFlowStepNav: FC<BuildFlowStepNavProps> = ({
+  recipeId,
+  className,
+}) => {
   const pathname = usePathname();
   const router = useRouter();
 
   const { data: recipeDetails } = useQuery({
-    queryKey: ["recipe-details", recipeId, "build-flow-nav"],
+    queryKey: buildFlowNavRecipeDetailsQueryKey(recipeId),
     queryFn: () => SpecService.getRecipeDetails(recipeId),
     enabled: Boolean(recipeId),
     staleTime: 10_000,
@@ -116,4 +120,4 @@ export function BuildFlowStepNav({ recipeId, className }: BuildFlowStepNavProps)
       })}
     </nav>
   );
-}
+};

--- a/lib/buildFlow.ts
+++ b/lib/buildFlow.ts
@@ -37,7 +37,8 @@ export function isRecipeInQuestionOnlyPhase(status: string | null | undefined): 
   if (u === "QUESTIONS_READY" || u === "PENDING_QUESTIONS") return true;
   if (u.includes("SPEC") || u.includes("PLAN")) return false;
   if (u.includes("QUESTION")) return true;
-  return false;
+  // Unrecognized status: stay conservative — keep Spec locked until we know Q&A is done.
+  return true;
 }
 
 /**

--- a/lib/buildFlow.ts
+++ b/lib/buildFlow.ts
@@ -67,8 +67,9 @@ export function computeMaxReachableStepIndex(
     max = Math.max(max, 2);
   }
 
+  // Code tab: not unlocked by PLAN_READY alone — user must use "Start implementation"
+  // on the plan page (or recipe status must reflect codegen / task-splitting).
   if (
-    (s.includes("PLAN") && (s.includes("READY") || s.includes("COMPLETE"))) ||
     s.includes("CODEGEN") ||
     s.includes("TASK_SPLITTING") ||
     s.includes("IMPLEMENTATION")
@@ -97,6 +98,33 @@ export function canNavigateToBuildFlowStep(
 /** sessionStorage key for last codegen query (planId / taskSplittingId) per recipe. */
 const codegenQueryStorageKey = (recipeId: string) =>
   `potpie_codegen_query_${recipeId}`;
+
+/** Set when implementation/codegen has been started so the Code tab stays reachable after leaving /code. */
+const codegenStartedStorageKey = (recipeId: string) =>
+  `potpie_codegen_started_${recipeId}`;
+
+export const CODEGEN_STARTED_EVENT = "potpie-codegen-started";
+
+export function markCodegenStartedForRecipe(recipeId: string): void {
+  if (typeof window === "undefined" || !recipeId) return;
+  try {
+    sessionStorage.setItem(codegenStartedStorageKey(recipeId), "1");
+    window.dispatchEvent(
+      new CustomEvent(CODEGEN_STARTED_EVENT, { detail: { recipeId } }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function hasCodegenStartedForRecipe(recipeId: string): boolean {
+  if (typeof window === "undefined" || !recipeId) return false;
+  try {
+    return sessionStorage.getItem(codegenStartedStorageKey(recipeId)) === "1";
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Persist last codegen URL query for a recipe so build-flow tabs can return to the

--- a/lib/buildFlow.ts
+++ b/lib/buildFlow.ts
@@ -127,6 +127,47 @@ export function hasCodegenStartedForRecipe(recipeId: string): boolean {
 }
 
 /**
+ * True when spec output has been produced at least once (recipe status reflects
+ * SPEC_READY or later build stages). Used for QnA primary button label.
+ */
+export function hasSpecBeenCompletedOnce(
+  recipeStatus: string | null | undefined,
+): boolean {
+  if (!recipeStatus) return false;
+  const u = recipeStatus.toUpperCase();
+  if (u === "SPEC_READY") return true;
+  if (
+    u.includes("PLAN") ||
+    u.includes("CODEGEN") ||
+    u.includes("TASK_SPLITTING") ||
+    u.includes("IMPLEMENTATION")
+  ) {
+    return true;
+  }
+  if (u.includes("SPEC") && (u.includes("READY") || u.includes("COMPLETE"))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True when implementation/codegen has been started before (recipe status or session).
+ * Used for Plan "Start implementation" button label.
+ */
+export function hasImplementationBeenStartedBefore(
+  recipeStatus: string | null | undefined,
+  sessionCodegenStarted: boolean,
+): boolean {
+  if (sessionCodegenStarted) return true;
+  const s = (recipeStatus ?? "").toUpperCase();
+  return (
+    s.includes("CODEGEN") ||
+    s.includes("TASK_SPLITTING") ||
+    s.includes("IMPLEMENTATION")
+  );
+}
+
+/**
  * Persist last codegen URL query for a recipe so build-flow tabs can return to the
  * same slice / taskSplittingId instead of `/code` bare (which defaults itemNumber=1).
  */

--- a/lib/buildFlow.ts
+++ b/lib/buildFlow.ts
@@ -1,0 +1,132 @@
+/** Build flow steps: QnA → Spec → Plan → Codegen (task routes). */
+
+export type BuildFlowStep = "qna" | "spec" | "plan" | "code";
+
+export const BUILD_FLOW_STEP_ORDER: BuildFlowStep[] = [
+  "qna",
+  "spec",
+  "plan",
+  "code",
+];
+
+export const BUILD_FLOW_STEPS: Array<{
+  id: BuildFlowStep;
+  label: string;
+  path: string;
+}> = [
+  { id: "qna", label: "Q&A", path: "/qna" },
+  { id: "spec", label: "Spec", path: "/spec" },
+  { id: "plan", label: "Plan", path: "/plan" },
+  { id: "code", label: "Code", path: "/code" },
+];
+
+export function buildFlowStepFromPathname(pathname: string | null): BuildFlowStep {
+  if (!pathname) return "qna";
+  if (pathname.includes("/code")) return "code";
+  if (pathname.includes("/plan")) return "plan";
+  if (pathname.includes("/spec")) return "spec";
+  if (pathname.includes("/qna")) return "qna";
+  return "qna";
+}
+
+/** True while recipe is still in the clarifying-questions phase (spec not yet available). */
+export function isRecipeInQuestionOnlyPhase(status: string | null | undefined): boolean {
+  if (status == null || status === "") return true;
+  const u = status.toUpperCase();
+  if (u === "ANSWERS_SUBMITTED") return false;
+  if (u === "QUESTIONS_READY" || u === "PENDING_QUESTIONS") return true;
+  if (u.includes("SPEC") || u.includes("PLAN")) return false;
+  if (u.includes("QUESTION")) return true;
+  return false;
+}
+
+/**
+ * Furthest step index (0–3) the user may move forward to, based on recipe status and current URL.
+ * Back navigation always allows earlier steps; this caps forward jumps.
+ */
+export function computeMaxReachableStepIndex(
+  recipeStatus: string | null | undefined,
+  pathname: string | null
+): number {
+  const s = (recipeStatus ?? "").toUpperCase();
+  const path = pathname ?? "";
+
+  let max = 0;
+
+  if (!isRecipeInQuestionOnlyPhase(recipeStatus)) {
+    max = Math.max(max, 1);
+  }
+
+  if (
+    s === "SPEC_READY" ||
+    s.includes("PLAN") ||
+    s.includes("CODEGEN") ||
+    s.includes("TASK_SPLITTING") ||
+    s.includes("IMPLEMENTATION")
+  ) {
+    max = Math.max(max, 2);
+  }
+
+  if (
+    (s.includes("PLAN") && (s.includes("READY") || s.includes("COMPLETE"))) ||
+    s.includes("CODEGEN") ||
+    s.includes("TASK_SPLITTING") ||
+    s.includes("IMPLEMENTATION")
+  ) {
+    max = Math.max(max, 3);
+  }
+
+  if (path.includes("/spec")) max = Math.max(max, 1);
+  if (path.includes("/plan")) max = Math.max(max, 2);
+  if (path.includes("/code")) max = Math.max(max, 3);
+
+  return Math.min(max, 3);
+}
+
+export function canNavigateToBuildFlowStep(
+  target: BuildFlowStep,
+  active: BuildFlowStep,
+  maxReachableIndex: number
+): boolean {
+  const ti = BUILD_FLOW_STEP_ORDER.indexOf(target);
+  const ai = BUILD_FLOW_STEP_ORDER.indexOf(active);
+  if (ti <= ai) return true;
+  return ti <= maxReachableIndex;
+}
+
+/** sessionStorage key for last codegen query (planId / taskSplittingId) per recipe. */
+const codegenQueryStorageKey = (recipeId: string) =>
+  `potpie_codegen_query_${recipeId}`;
+
+/**
+ * Persist last codegen URL query for a recipe so build-flow tabs can return to the
+ * same slice / taskSplittingId instead of `/code` bare (which defaults itemNumber=1).
+ */
+export function persistCodegenQueryString(
+  recipeId: string,
+  search: string
+): void {
+  if (typeof window === "undefined" || !recipeId) return;
+  const trimmed = search.startsWith("?") ? search.slice(1) : search;
+  if (!trimmed) return;
+  const params = new URLSearchParams(trimmed);
+  if (!params.get("planId") && !params.get("taskSplittingId")) return;
+  try {
+    sessionStorage.setItem(codegenQueryStorageKey(recipeId), trimmed);
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/** Prefer restoring last codegen query; fallback to bare code route. */
+export function getCodegenHrefForRecipe(recipeId: string): string {
+  const base = `/task/${recipeId}/code`;
+  if (typeof window === "undefined") return base;
+  try {
+    const stored = sessionStorage.getItem(codegenQueryStorageKey(recipeId));
+    if (stored) return `${base}?${stored}`;
+  } catch {
+    // ignore
+  }
+  return base;
+}

--- a/lib/buildFlow.ts
+++ b/lib/buildFlow.ts
@@ -199,3 +199,8 @@ export function getCodegenHrefForRecipe(recipeId: string): string {
   }
   return base;
 }
+
+/** React Query key for recipe details in BuildFlowStepNav; invalidate when plan (or recipe) progress updates status. */
+export function buildFlowNavRecipeDetailsQueryKey(recipeId: string) {
+  return ["recipe-details", recipeId, "build-flow-nav"] as const;
+}

--- a/lib/utils/recipeRedirect.ts
+++ b/lib/utils/recipeRedirect.ts
@@ -1,0 +1,40 @@
+/**
+ * Deep-link for a build flow (recipe) by status. Kept in sync with all-chats routing.
+ */
+export function getRecipeRedirectUrl(recipe: {
+  id?: string;
+  recipe_id?: string;
+  project_id?: string;
+  status?: string;
+}): string {
+  const recipeId = recipe.id || recipe.recipe_id;
+  const status = (recipe.status || "").toUpperCase();
+
+  if (status.includes("QUESTIONS")) {
+    const params = new URLSearchParams();
+    if (recipe.project_id) {
+      params.set("projectId", recipe.project_id);
+    }
+    if (recipeId) {
+      params.set("recipeId", recipeId);
+    }
+    return `/repo?${params.toString()}`;
+  }
+
+  if (status.includes("SPEC") || status === "ANSWERS_SUBMITTED") {
+    return `/task/${recipeId}/spec`;
+  }
+
+  if (status.includes("PLAN")) {
+    return `/task/${recipeId}/plan`;
+  }
+
+  const params = new URLSearchParams();
+  if (recipe.project_id) {
+    params.set("projectId", recipe.project_id);
+  }
+  if (recipeId) {
+    params.set("recipeId", recipeId);
+  }
+  return `/repo?${params.toString()}`;
+}

--- a/services/BranchAndRepositoryService.ts
+++ b/services/BranchAndRepositoryService.ts
@@ -335,16 +335,36 @@ export default class BranchAndRepositoryService {
               return status;
           }
         };
+
+        const shouldAdvanceToNextStep = (status: string) =>
+          status === ParsingStatusEnum.INFERRING ||
+          status === ParsingStatusEnum.READY;
+
+        if (shouldAdvanceToNextStep(parsingStatus)) {
+          if (setChatStep) {
+            setChatStep(2);
+          }
+          setParsingStatus(
+            parsingStatus === ParsingStatusEnum.READY
+              ? ParsingStatusEnum.READY
+              : getStatusMessage(parsingStatus)
+          );
+          return;
+        }
     
         while (parsingStatus !== ParsingStatusEnum.READY && Date.now() - startTime < maxDuration) {
           parsingStatus = await BranchAndRepositoryService.getParsingStatus(projectId);
           setParsingStatus(getStatusMessage(parsingStatus));
     
-          if (parsingStatus === ParsingStatusEnum.READY) {
+          if (shouldAdvanceToNextStep(parsingStatus)) {
             if (setChatStep) {
               setChatStep(2); 
             }
-            setParsingStatus(ParsingStatusEnum.READY);
+            setParsingStatus(
+              parsingStatus === ParsingStatusEnum.READY
+                ? ParsingStatusEnum.READY
+                : getStatusMessage(parsingStatus)
+            );
             return;
           }
     


### PR DESCRIPTION
Added 4 switch tabs to switch between Q&A, spec, Plan and code pages. Tabs disabled for steps that have not been completed. 

<img width="1920" height="1080" alt="Screenshot 2026-04-10 at 4 58 56 PM (2)" src="https://github.com/user-attachments/assets/37549d23-e59d-4cf5-932d-79fa0b8056fb" />
<img width="1920" height="1080" alt="Screenshot 2026-04-10 at 4 58 09 PM (2)" src="https://github.com/user-attachments/assets/c15a2a6c-64a9-41ee-a8c2-6e54f820256c" />

if switched to previous page, button below shows "re-generation"
<img width="1918" height="1080" alt="Screenshot 2026-04-10 at 6 02 28 PM" src="https://github.com/user-attachments/assets/f8d850a4-a662-415d-889c-753eb03d7033" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progressive build-flow navigation across QnA → Spec → Plan → Code with gated unlocks and a visual step navigator.
  * Persistence for code-generation state and query parameters so prior plan/task selections are restored when returning to Code.
  * Deep-link generation for recipe items to route users to the appropriate workflow page.

* **UI/UX Improvements**
  * Unified, responsive top header showing repository, branch and step navigation across task pages.
  * Contextual CTA labels (e.g., “RE-GENERATE PLAN”, “RE-START IMPLEMENTATION”) based on status.
  * Consolidated chat/history list to include build items and refined borders, spacing and loading layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->