### PR TITLE
Fix ui bugs 2

### DIFF
--- a/app/(main)/task/[taskId]/code/page.tsx
+++ b/app/(main)/task/[taskId]/code/page.tsx
@@ -2689,7 +2689,7 @@ export default function VerticalTaskExecution() {
 
         {/* Right: Code generation */}
         <div className="overflow-hidden flex-none flex flex-col w-1/2 min-w-0">
-          <aside className="h-full w-full min-w-[320px] flex flex-col border-l border-[#E5E8E6]">
+          <aside className="h-full w-full min-w-[320px] flex flex-col">
             <div className="p-6 border-b border-[#E5E8E6] bg-white">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2 min-w-0">

--- a/app/(main)/task/[taskId]/code/page.tsx
+++ b/app/(main)/task/[taskId]/code/page.tsx
@@ -30,6 +30,7 @@ import {
   TestTube,
   ScrollText,
   ChevronDown,
+  ChevronUp,
   FileText,
   Copy,
   Clock,
@@ -360,6 +361,11 @@ const CodeFileCard = ({
         <span className="text-xs font-medium text-[#022019] truncate">
           {change.path}
         </span>
+        {isExpanded ? (
+          <ChevronUp className="w-4 h-4 text-[#022019] shrink-0" />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-[#022019] shrink-0" />
+        )}
       </button>
       {isExpanded && (
         <div className="min-h-[280px]">

--- a/app/(main)/task/[taskId]/plan/page.tsx
+++ b/app/(main)/task/[taskId]/plan/page.tsx
@@ -887,7 +887,7 @@ const PlanPage = () => {
         </div>
 
         {/* Right: Phase Plan panel (top bar matches Spec page) */}
-        <aside className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 border-l border-[#E5E8E6]">
+        <aside className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0">
           <div className="p-6 border-b border-[#E5E8E6] bg-[#FFFDFC] shrink-0">
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-2">

--- a/app/(main)/task/[taskId]/plan/page.tsx
+++ b/app/(main)/task/[taskId]/plan/page.tsx
@@ -7,6 +7,7 @@ import {
   Check,
   Loader2,
   ChevronDown,
+  ChevronUp,
   ChevronLeft,
   ChevronRight,
   FileCode,
@@ -282,6 +283,8 @@ const PlanPage = () => {
   const [chatLoading, setChatLoading] = useState(false);
   const [selectedPhaseIndex, setSelectedPhaseIndex] = useState(0);
   const [expandedPhases, setExpandedPhases] = useState<Set<number>>(new Set([0]));
+  const [collapsedArchitectureDiagrams, setCollapsedArchitectureDiagrams] =
+    useState<Set<string>>(new Set());
   const [isRegeneratingPlan, setIsRegeneratingPlan] = useState(false);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const hasChatInitializedRef = useRef(false);
@@ -1053,32 +1056,71 @@ const PlanPage = () => {
                   <TabsContent value="architecture" className="mt-4 pt-2 pb-12 pr-4">
                     <div className="py-5 pr-2 space-y-6">
                       {phase.diagrams && phase.diagrams.length > 0 ? (
-                        phase.diagrams.map((d) => (
-                          <div
-                            key={d.diagram_id}
-                            className="border rounded-lg p-4 overflow-x-auto bg-[#FFFDFC]"
-                            style={{ borderColor: "#CCD3CF" }}
-                          >
-                            <h4 className="text-sm font-semibold text-[#022019] mb-1">{d.title}</h4>
-                            {d.description && (
-                              <p className="text-xs text-[#374151] mb-3 leading-relaxed">{d.description}</p>
-                            )}
-                            {d.mermaid_code ? (
-                              looksLikeMermaid(d.mermaid_code) ? (
-                                <MermaidDiagram chart={d.mermaid_code} />
-                              ) : (
-                                <pre className="text-xs font-mono text-gray-800 whitespace-pre-wrap break-words m-0 p-0">
-                                  {d.mermaid_code}
-                                </pre>
-                              )
-                            ) : (
-                              <p className="text-xs text-zinc-500 italic">No diagram content.</p>
-                            )}
-                            {d.validation_error && (
-                              <p className="text-xs text-amber-700 mt-2">Validation: {d.validation_error}</p>
-                            )}
-                          </div>
-                        ))
+                        phase.diagrams.map((d) => {
+                          const diagramKey = `${selectedPhaseIndex}-${d.diagram_id}`;
+                          const isCollapsed =
+                            collapsedArchitectureDiagrams.has(diagramKey);
+                          return (
+                            <div
+                              key={d.diagram_id}
+                              className="border rounded-lg p-4 overflow-x-auto bg-[#FFFDFC]"
+                              style={{ borderColor: "#CCD3CF" }}
+                            >
+                              <div className="flex items-start justify-between gap-3 mb-1">
+                                <h4 className="text-sm font-semibold text-[#022019]">
+                                  {d.title}
+                                </h4>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setCollapsedArchitectureDiagrams((prev) => {
+                                      const next = new Set(prev);
+                                      if (isCollapsed) {
+                                        next.delete(diagramKey);
+                                      } else {
+                                        next.add(diagramKey);
+                                      }
+                                      return next;
+                                    })
+                                  }
+                                  className="shrink-0 rounded-sm p-1 text-[#747575] hover:text-[#022019] hover:bg-zinc-100 transition-colors"
+                                  aria-label={`${isCollapsed ? "Open" : "Collapse"} ${d.title} diagram`}
+                                  title={isCollapsed ? "Open diagram" : "Collapse diagram"}
+                                >
+                                  {isCollapsed ? (
+                                    <ChevronDown className="w-4 h-4" />
+                                  ) : (
+                                    <ChevronUp className="w-4 h-4" />
+                                  )}
+                                </button>
+                              </div>
+                              {d.description && (
+                                <p className="text-xs text-[#374151] mb-3 leading-relaxed">
+                                  {d.description}
+                                </p>
+                              )}
+                              {!isCollapsed &&
+                                (d.mermaid_code ? (
+                                  looksLikeMermaid(d.mermaid_code) ? (
+                                    <MermaidDiagram chart={d.mermaid_code} />
+                                  ) : (
+                                    <pre className="text-xs font-mono text-gray-800 whitespace-pre-wrap break-words m-0 p-0">
+                                      {d.mermaid_code}
+                                    </pre>
+                                  )
+                                ) : (
+                                  <p className="text-xs text-zinc-500 italic">
+                                    No diagram content.
+                                  </p>
+                                ))}
+                              {d.validation_error && (
+                                <p className="text-xs text-amber-700 mt-2">
+                                  Validation: {d.validation_error}
+                                </p>
+                              )}
+                            </div>
+                          );
+                        })
                       ) : (
                         <p className="text-sm text-[#374151] leading-relaxed">
                           No architecture diagram available for this phase.

--- a/app/(main)/task/[taskId]/spec/page.tsx
+++ b/app/(main)/task/[taskId]/spec/page.tsx
@@ -1139,7 +1139,7 @@ const SpecPage = () => {
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left: Chat area — fixed height so only messages scroll; input always visible */}
-        <div className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-r-[1px] border-[#E5E8E6] bg-[#FAF8F7] chat-panel-contained">
+        <div className="w-1/2 max-w-[50%] flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-[#E5E8E6] bg-[#FAF8F7] chat-panel-contained">
           {/* Messages — only this section scrolls */}
           <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-6 py-4 space-y-4">
             {chatMessages.map((msg, i) => (
@@ -1243,7 +1243,7 @@ const SpecPage = () => {
             transition: "width 0.35s ease-out",
           }}
         >
-          <aside className="h-full w-full min-w-[280px] flex flex-col border-l border-l-[1px] border-[#E5E8E6]">
+          <aside className="h-full w-full min-w-[280px] flex flex-col">
             <div className="p-6 border-b border-[#E5E8E6]">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2 min-w-0 flex-1 justify-between">

--- a/components/Layouts/ChatHistoryPanel.tsx
+++ b/components/Layouts/ChatHistoryPanel.tsx
@@ -624,7 +624,7 @@ export function ChatHistoryPanel() {
                       onMouseEnter={() => setHoveredChatId(rowKey)}
                       onMouseLeave={() => setHoveredChatId(null)}
                       className={cn(
-                        "group mx-1 flex items-center justify-between pl-4 pr-2 py-1.5 rounded-md cursor-pointer text-sm transition-colors overflow-hidden",
+                        "group ml-4 flex items-center justify-between px-2 py-1.5 rounded-md cursor-pointer text-sm transition-colors",
                         isActive
                           ? "bg-[#F4F4F4] text-primary font-medium"
                           : "hover:bg-[#F4F4F4] text-zinc-700"
@@ -633,7 +633,7 @@ export function ChatHistoryPanel() {
                       <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
                         {!isRecipe && (
                           <span
-                            className="shrink-0 inline-flex items-center justify-center min-w-[36px] rounded px-1 py-0 text-[0.6rem] font-light text-zinc-900"
+                            className="shrink-0 rounded px-1 py-[1px] text-[0.6rem] font-light text-zinc-900"
                             style={{ backgroundColor: "#DAF1A1" }}
                             title="Chat"
                           >
@@ -642,7 +642,7 @@ export function ChatHistoryPanel() {
                         )}
                         {isRecipe && (
                           <span
-                            className="shrink-0 inline-flex items-center justify-center min-w-[36px] rounded px-1 py-0 text-[0.6rem] font-light bg-blue-100 text-blue-900"
+                            className="shrink-0 rounded px-1 py-[1px] text-[0.6rem] font-light bg-blue-100 text-blue-900"
                             title="Build flow"
                           >
                             Build

--- a/components/Layouts/ChatHistoryPanel.tsx
+++ b/components/Layouts/ChatHistoryPanel.tsx
@@ -624,7 +624,7 @@ export function ChatHistoryPanel() {
                       onMouseEnter={() => setHoveredChatId(rowKey)}
                       onMouseLeave={() => setHoveredChatId(null)}
                       className={cn(
-                        "group ml-4 flex items-center justify-between px-2 py-1.5 rounded-md cursor-pointer text-sm transition-colors",
+                        "group mx-1 flex items-center justify-between pl-4 pr-2 py-1.5 rounded-md cursor-pointer text-sm transition-colors overflow-hidden",
                         isActive
                           ? "bg-[#F4F4F4] text-primary font-medium"
                           : "hover:bg-[#F4F4F4] text-zinc-700"
@@ -633,7 +633,7 @@ export function ChatHistoryPanel() {
                       <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
                         {!isRecipe && (
                           <span
-                            className="shrink-0 rounded px-1 py-[1px] text-[0.6rem] font-light text-zinc-900"
+                            className="shrink-0 inline-flex items-center justify-center min-w-[36px] rounded px-1 py-0 text-[0.6rem] font-light text-zinc-900"
                             style={{ backgroundColor: "#DAF1A1" }}
                             title="Chat"
                           >
@@ -642,7 +642,7 @@ export function ChatHistoryPanel() {
                         )}
                         {isRecipe && (
                           <span
-                            className="shrink-0 rounded px-1 py-[1px] text-[0.6rem] font-light bg-blue-100 text-blue-900"
+                            className="shrink-0 inline-flex items-center justify-center min-w-[36px] rounded px-1 py-0 text-[0.6rem] font-light bg-blue-100 text-blue-900"
                             title="Build flow"
                           >
                             Build

--- a/components/chat/MermaidDiagram.tsx
+++ b/components/chat/MermaidDiagram.tsx
@@ -2,7 +2,7 @@
 
 import React, { FC, useState, useEffect, useRef, useMemo } from "react";
 import { Button } from "@/components/ui/button";
-import { LucideCopy, LucideCopyCheck, Maximize2 } from "lucide-react";
+import { LucideCopy, LucideCopyCheck, Maximize2, X } from "lucide-react";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 
 interface MermaidDiagramProps {
@@ -850,6 +850,16 @@ export const MermaidDiagram: FC<MermaidDiagramProps> = ({ chart }) => {
                     ) : (
                       <LucideCopy className="size-3" />
                     )}
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setIsModalOpen(false);
+                    }}
+                    aria-label="Close full screen diagram"
+                    className="text-xs font-medium px-2 py-1 h-6 rounded bg-white/90 hover:bg-white border border-gray-200 shadow-sm cursor-pointer flex items-center transition-colors text-gray-800"
+                  >
+                    <X className="size-3" />
                   </button>
                 </div>
                 <div


### PR DESCRIPTION
1. Added up/down chevron in codegen file cards to collapse and open the code file.
<img width="842" height="816" alt="Screenshot 2026-04-22 at 6 18 23 PM" src="https://github.com/user-attachments/assets/2823cb08-93f1-442a-8167-90349f537fe9" />

2. Added up/down chevron to collapse/open architecture diag card + close button for expanded diagram.
<img width="822" height="654" alt="Screenshot 2026-04-22 at 6 43 25 PM" src="https://github.com/user-attachments/assets/e72c8cfb-bd2d-4d26-a9a4-48e3a62d89bc" /> 
<img width="1490" height="886" alt="Screenshot 2026-04-22 at 6 42 52 PM" src="https://github.com/user-attachments/assets/9bd05951-e4bd-4d7b-b852-5e67592d8046" />

4. Divider margin in Build flow made slimmer.
<img width="1851" height="993" alt="Screenshot 2026-04-22 at 6 04 54 PM" src="https://github.com/user-attachments/assets/f8427976-7530-4e0d-9cdc-f1b3964094f3" />


 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Individual architecture diagrams can now be collapsed and expanded independently
  * Added close button to the full-screen diagram view

* **Style & Layout**
  * Improved chevron icons to dynamically indicate expand/collapse state
  * Refined visual dividers and spacing across code, plan, and specification panels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->