### PR TITLE
Tool tip of sidebar fixed

### DIFF
--- a/components/Layouts/Sidebar.tsx
+++ b/components/Layouts/Sidebar.tsx
@@ -54,6 +54,7 @@ import { ChatHistoryPanel } from "./ChatHistoryPanel";
 import {
   Tooltip,
   TooltipContent,
+  TooltipPortal,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
@@ -212,9 +213,11 @@ export function AppSidebar() {
                     </Button>
                   </TooltipTrigger>
                   {!open && (
-                    <TooltipContent side="right" className="text-xs">
-                      Open Sidebar
-                    </TooltipContent>
+                    <TooltipPortal>
+                      <TooltipContent side="right" className="z-[80] text-xs">
+                        Open Sidebar
+                      </TooltipContent>
+                    </TooltipPortal>
                   )}
                 </Tooltip>
               </TooltipProvider>


### PR DESCRIPTION
1. Tool tip of sidebar was hiding behind top navbar. now fixed.
<img width="904" height="914" alt="Screenshot 2026-04-28 at 12 52 58 PM" src="https://github.com/user-attachments/assets/dc48dd1d-92ab-4001-87e5-1240fa7405c7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sidebar collapse tooltip display with enhanced rendering and proper layering, ensuring it appears correctly above other page elements when the sidebar is minimized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->