### PR TITLE
fix(ci): add frontend P2 digest promotion controls

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -2,6 +2,11 @@ name: Build and Deploy to Prod Artifact and Cloud Run
 
 on:
   workflow_dispatch:
+    inputs:
+      image_digest_ref:
+        description: "Existing immutable image digest ref (repo@sha256:...) to promote"
+        required: false
+        type: string
 
 env:
   PROJECT_ID: ${{ secrets.PROD_GCLOUD_PROJECT_ID }}
@@ -9,9 +14,11 @@ env:
   GAR_ZONE: us-central1 # artifact registry zone
   GAR_REPO: potpie-frontend # updated artifact registry repository
   CLOUD_RUN_SERVICE: potpie-frontend-stage # Add this line for Cloud Run service name
+  PROMOTE_IMAGE_DIGEST_REF: ${{ github.event.inputs.image_digest_ref }}
 
 jobs:
   quality-gates:
+    if: github.event.inputs.image_digest_ref == ''
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -40,6 +47,7 @@ jobs:
 
   setup-build-publish-deploy:
     needs: [quality-gates]
+    if: always() && (needs.quality-gates.result == 'success' || needs.quality-gates.result == 'skipped')
     name: Setup, Build, Publish, and Deploy
     runs-on: ubuntu-latest
     environment: production
@@ -115,6 +123,7 @@ jobs:
           echo "NEXT_PUBLIC_GOOGLE_SSO_CLIENT_ID=${{ secrets.PROD_NEXT_PUBLIC_GOOGLE_SSO_CLIENT_ID }}" >> $GITHUB_ENV
       # Build the Docker image
       - name: Build
+        if: env.PROMOTE_IMAGE_DIGEST_REF == ''
         run: |-
           SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
           IMAGE_TAG="$GAR_ZONE-docker.pkg.dev/$PROJECT_ID/$GAR_REPO/$IMAGE:$SHORT_SHA"
@@ -151,14 +160,44 @@ jobs:
 
       # Push the Docker image to Google Artifact Registry
       - name: Publish
+        if: env.PROMOTE_IMAGE_DIGEST_REF == ''
         run: |-
           docker push "$IMAGE_TAG"
+
+      - name: Capture image digest
+        if: env.PROMOTE_IMAGE_DIGEST_REF == ''
+        id: capture-digest
+        run: |-
+          IMAGE_DIGEST_REF=$(gcloud artifacts docker images describe "$IMAGE_TAG" --format='value(image_summary.fully_qualified_digest)' || true)
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            IMAGE_DIGEST_REF=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_TAG" || true)
+          fi
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            echo "Failed to resolve digest for $IMAGE_TAG" >&2
+            exit 1
+          fi
+          echo "IMAGE_DIGEST_REF=$IMAGE_DIGEST_REF" >> $GITHUB_ENV
+
+      - name: Select promoted digest
+        run: |-
+          if [ -n "$PROMOTE_IMAGE_DIGEST_REF" ]; then
+            IMAGE_DIGEST_REF="$PROMOTE_IMAGE_DIGEST_REF"
+          fi
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            echo "No IMAGE_DIGEST_REF available for deployment" >&2
+            exit 1
+          fi
+          if [[ "$IMAGE_DIGEST_REF" != *@sha256:* ]]; then
+            echo "IMAGE_DIGEST_REF must be immutable and include @sha256:. Got: $IMAGE_DIGEST_REF" >&2
+            exit 1
+          fi
+          echo "IMAGE_DIGEST_REF=$IMAGE_DIGEST_REF" >> $GITHUB_ENV
 
       # Deploy to Cloud Run
       - name: Deploy to Cloud Run
         run: |-
           gcloud run deploy ${{ env.CLOUD_RUN_SERVICE }} \
-            --image ${{ env.IMAGE_TAG }} \
+            --image ${{ env.IMAGE_DIGEST_REF }} \
             --project ${{ env.PROJECT_ID }} \
             --region ${{ env.GAR_ZONE }} \
             --platform managed \

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -52,6 +52,8 @@ jobs:
     env:
       STAGE_GCP_WIF_PROVIDER: ${{ secrets.STAGE_GCP_WIF_PROVIDER }}
       STAGE_GCP_WIF_SERVICE_ACCOUNT: ${{ secrets.STAGE_GCP_WIF_SERVICE_ACCOUNT }}
+    outputs:
+      image_digest_ref: ${{ steps.capture-digest.outputs.image_digest_ref }}
 
     steps:
       - name: Checkout
@@ -166,11 +168,25 @@ jobs:
         run: |-
           docker push "$IMAGE_TAG"
 
+      - name: Capture image digest
+        id: capture-digest
+        run: |-
+          IMAGE_DIGEST_REF=$(gcloud artifacts docker images describe "$IMAGE_TAG" --format='value(image_summary.fully_qualified_digest)' || true)
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            IMAGE_DIGEST_REF=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_TAG" || true)
+          fi
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            echo "Failed to resolve digest for $IMAGE_TAG" >&2
+            exit 1
+          fi
+          echo "IMAGE_DIGEST_REF=$IMAGE_DIGEST_REF" >> $GITHUB_ENV
+          echo "image_digest_ref=$IMAGE_DIGEST_REF" >> $GITHUB_OUTPUT
+
       # Deploy to Cloud Run
       - name: Deploy to Cloud Run
         run: |-
           gcloud run deploy ${{ env.CLOUD_RUN_SERVICE }} \
-            --image ${{ env.IMAGE_TAG }} \
+            --image ${{ env.IMAGE_DIGEST_REF }} \
             --project ${{ env.PROJECT_ID }} \
             --region ${{ env.GAR_ZONE }} \
             --platform managed \

--- a/.github/workflows/pr-cloud-run.yaml
+++ b/.github/workflows/pr-cloud-run.yaml
@@ -188,11 +188,23 @@ jobs:
         run: |-
           docker push "$IMAGE_TAG"
 
+      - name: Capture image digest
+        run: |-
+          IMAGE_DIGEST_REF=$(gcloud artifacts docker images describe "$IMAGE_TAG" --format='value(image_summary.fully_qualified_digest)' || true)
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            IMAGE_DIGEST_REF=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_TAG" || true)
+          fi
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            echo "Failed to resolve digest for $IMAGE_TAG" >&2
+            exit 1
+          fi
+          echo "IMAGE_DIGEST_REF=$IMAGE_DIGEST_REF" >> $GITHUB_ENV
+
       # Deploy to Cloud Run
       - name: Deploy to Cloud Run
         run: |-
           gcloud run deploy "pr-${SANITIZED_BRANCH_NAME}" \
-            --image "$IMAGE_TAG" \
+            --image "$IMAGE_DIGEST_REF" \
             --project "$PROJECT_ID" \
             --region $GAR_ZONE \
             --platform managed \
@@ -222,6 +234,9 @@ jobs:
     if: github.event.action == 'closed'
     name: Cleanup Cloud Run Service
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     env:
       STAGE_GCP_WIF_PROVIDER: ${{ secrets.STAGE_GCP_WIF_PROVIDER }}
       STAGE_GCP_WIF_SERVICE_ACCOUNT: ${{ secrets.STAGE_GCP_WIF_SERVICE_ACCOUNT }}

--- a/.github/workflows/upload-image.yaml
+++ b/.github/workflows/upload-image.yaml
@@ -170,3 +170,33 @@ jobs:
       - name: Publish
         run: |-
           docker push "$IMAGE_TAG"
+
+      - name: Capture image digest
+        run: |-
+          IMAGE_DIGEST_REF=$(gcloud artifacts docker images describe "$IMAGE_TAG" --format='value(image_summary.fully_qualified_digest)' || true)
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            IMAGE_DIGEST_REF=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_TAG" || true)
+          fi
+          if [ -z "$IMAGE_DIGEST_REF" ]; then
+            echo "Failed to resolve digest for $IMAGE_TAG" >&2
+            exit 1
+          fi
+          echo "IMAGE_DIGEST_REF=$IMAGE_DIGEST_REF" >> $GITHUB_ENV
+
+      - name: Persist image metadata
+        run: |-
+          cat > image-metadata.json <<EOF
+          {
+            "image_tag": "${IMAGE_TAG}",
+            "image_digest_ref": "${IMAGE_DIGEST_REF}",
+            "project_id": "${PROJECT_ID}",
+            "repository": "${GAR_REPO}",
+            "commit_sha": "${GITHUB_SHA}"
+          }
+          EOF
+
+      - name: Upload image metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: image-metadata
+          path: image-metadata.json


### PR DESCRIPTION
## Summary
- capture and persist immutable image digest references across staging, prod, PR, and upload workflows
- support build-once promote-by-digest in prod using `workflow_dispatch` digest input
- harden PR cleanup auth permissions and keep deploy steps pinned to digest refs

## Test plan
- [ ] Trigger staging deploy and verify Cloud Run deploy uses `repo@sha256:*`
- [ ] Trigger prod deploy with `image_digest_ref` input and verify build/publish are skipped
- [ ] Trigger PR workflow open/close and verify deploy + cleanup auth paths both succeed
