### PR TITLE
Quick repo selection using '+' on repo folder

### DIFF
--- a/app/(main)/newchat/page.tsx
+++ b/app/(main)/newchat/page.tsx
@@ -320,7 +320,6 @@ export default function NewChatPage() {
 
     const availableBranches = Array.isArray(branches) ? branches : [];
     let resolvedBranch = "";
-    let resolvedFromVerifiedQueryBranch = false;
 
     if (quickStartBranchQuery) {
       if (
@@ -328,7 +327,6 @@ export default function NewChatPage() {
         availableBranches.includes(quickStartBranchQuery)
       ) {
         resolvedBranch = quickStartBranchQuery;
-        resolvedFromVerifiedQueryBranch = true;
       } else {
         toast.error(
           `Branch '${quickStartBranchQuery}' not found. Using fallback branch.`
@@ -360,7 +358,7 @@ export default function NewChatPage() {
         ? prev
         : { ...prev, selectedBranch: resolvedBranch }
     );
-    if (resolvedFromVerifiedQueryBranch) {
+    if (resolvedBranch) {
       setHasResolvedBranchFromQuery(true);
     }
 

--- a/app/(main)/newchat/page.tsx
+++ b/app/(main)/newchat/page.tsx
@@ -103,6 +103,10 @@ export default function NewChatPage() {
 
   const [repoSearch, setRepoSearch] = useState<string>("");
   const [branchSearch, setBranchSearch] = useState<string>("");
+  const [hasPrefilledRepoFromQuery, setHasPrefilledRepoFromQuery] =
+    useState(false);
+  const [hasResolvedBranchFromQuery, setHasResolvedBranchFromQuery] =
+    useState(false);
 
   const [isLocalhost, setIsLocalhost] = useState(false);
   useEffect(() => {
@@ -114,6 +118,8 @@ export default function NewChatPage() {
   }, []);
 
   const isDemoMode = searchParams.get("demo") === "true";
+  const quickStartRepoQuery = searchParams.get("repo")?.trim() || "";
+  const quickStartBranchQuery = searchParams.get("branch")?.trim() || "";
 
 
   const {
@@ -248,6 +254,121 @@ export default function NewChatPage() {
       return { ...prev, linkedRepos: repositories };
     });
   }, [repositories, repoSearch]);
+
+  useEffect(() => {
+    setHasPrefilledRepoFromQuery(false);
+    setHasResolvedBranchFromQuery(false);
+  }, [quickStartRepoQuery, quickStartBranchQuery]);
+
+  useEffect(() => {
+    if (!quickStartRepoQuery || hasPrefilledRepoFromQuery) {
+      return;
+    }
+    if (reposLoading) {
+      return;
+    }
+
+    const normalize = (name: string) =>
+      name.trim().toLowerCase().replace(/\.git$/i, "");
+    const normalizedQuery = normalize(quickStartRepoQuery);
+
+    const matchedRepo = repositories.find((repo: Repo) => {
+      const fullName = normalize(repo.full_name || "");
+      const repoName = normalize(repo.name || "");
+      return fullName === normalizedQuery || repoName === normalizedQuery;
+    });
+
+    if (!matchedRepo) {
+      toast.error("Repository not found in linked repositories");
+      setHasPrefilledRepoFromQuery(true);
+      setHasResolvedBranchFromQuery(true);
+      return;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      selectedRepo: matchedRepo.id?.toString() || prev.selectedRepo,
+      selectedBranch: null,
+    }));
+    setHasPrefilledRepoFromQuery(true);
+  }, [
+    quickStartRepoQuery,
+    hasPrefilledRepoFromQuery,
+    reposLoading,
+    repositories,
+  ]);
+
+  useEffect(() => {
+    if (!quickStartRepoQuery || !hasPrefilledRepoFromQuery || hasResolvedBranchFromQuery) {
+      return;
+    }
+    if (!state.selectedRepo || branchesLoading) {
+      return;
+    }
+
+    const selectedRepoData = repositories.find(
+      (repo: Repo) => repo.id?.toString() === state.selectedRepo
+    );
+    if (!selectedRepoData) {
+      setHasResolvedBranchFromQuery(true);
+      return;
+    }
+
+    const availableBranches = Array.isArray(branches) ? branches : [];
+    let resolvedBranch = "";
+
+    if (quickStartBranchQuery) {
+      if (
+        availableBranches.length === 0 ||
+        availableBranches.includes(quickStartBranchQuery)
+      ) {
+        resolvedBranch = quickStartBranchQuery;
+      } else {
+        toast.error(
+          `Branch '${quickStartBranchQuery}' not found. Using fallback branch.`
+        );
+      }
+    }
+
+    if (
+      !resolvedBranch &&
+      selectedRepoData.default_branch &&
+      (availableBranches.length === 0 ||
+        availableBranches.includes(selectedRepoData.default_branch))
+    ) {
+      resolvedBranch = selectedRepoData.default_branch;
+    }
+
+    if (!resolvedBranch) {
+      if (availableBranches.includes("main")) {
+        resolvedBranch = "main";
+      } else if (availableBranches.length > 0) {
+        resolvedBranch = availableBranches[0];
+      } else {
+        resolvedBranch = selectedRepoData.default_branch || "main";
+      }
+    }
+
+    setState((prev) =>
+      prev.selectedBranch === resolvedBranch
+        ? prev
+        : { ...prev, selectedBranch: resolvedBranch }
+    );
+    setHasResolvedBranchFromQuery(true);
+
+    setTimeout(() => {
+      textareaRef.current?.focus();
+    }, 0);
+  }, [
+    quickStartRepoQuery,
+    quickStartBranchQuery,
+    hasPrefilledRepoFromQuery,
+    hasResolvedBranchFromQuery,
+    state.selectedRepo,
+    branchesLoading,
+    branches,
+    repositories,
+  ]);
 
   useEffect(() => {
     if (isDemoMode && repositories.length > 0) {

--- a/app/(main)/newchat/page.tsx
+++ b/app/(main)/newchat/page.tsx
@@ -280,6 +280,11 @@ export default function NewChatPage() {
 
     if (!matchedRepo) {
       toast.error("Repository not found in linked repositories");
+      setState((prev) => ({
+        ...prev,
+        selectedRepo: null,
+        selectedBranch: null,
+      }));
       setHasPrefilledRepoFromQuery(true);
       setHasResolvedBranchFromQuery(true);
       return;
@@ -310,19 +315,20 @@ export default function NewChatPage() {
       (repo: Repo) => repo.id?.toString() === state.selectedRepo
     );
     if (!selectedRepoData) {
-      setHasResolvedBranchFromQuery(true);
       return;
     }
 
     const availableBranches = Array.isArray(branches) ? branches : [];
     let resolvedBranch = "";
+    let resolvedFromVerifiedQueryBranch = false;
 
     if (quickStartBranchQuery) {
       if (
-        availableBranches.length === 0 ||
+        availableBranches.length > 0 &&
         availableBranches.includes(quickStartBranchQuery)
       ) {
         resolvedBranch = quickStartBranchQuery;
+        resolvedFromVerifiedQueryBranch = true;
       } else {
         toast.error(
           `Branch '${quickStartBranchQuery}' not found. Using fallback branch.`
@@ -333,7 +339,7 @@ export default function NewChatPage() {
     if (
       !resolvedBranch &&
       selectedRepoData.default_branch &&
-      (availableBranches.length === 0 ||
+      (availableBranches.length > 0 &&
         availableBranches.includes(selectedRepoData.default_branch))
     ) {
       resolvedBranch = selectedRepoData.default_branch;
@@ -354,7 +360,9 @@ export default function NewChatPage() {
         ? prev
         : { ...prev, selectedBranch: resolvedBranch }
     );
-    setHasResolvedBranchFromQuery(true);
+    if (resolvedFromVerifiedQueryBranch) {
+      setHasResolvedBranchFromQuery(true);
+    }
 
     setTimeout(() => {
       textareaRef.current?.focus();

--- a/components/Layouts/ChatHistoryPanel.tsx
+++ b/components/Layouts/ChatHistoryPanel.tsx
@@ -590,9 +590,17 @@ export function ChatHistoryPanel() {
             </div>
           ) : (
             groupedItems.map((group) => {
-              const quickStartBranch = group.items.find(
-                (item: any) => item.branch && String(item.branch).trim().length > 0
-              )?.branch as string | undefined;
+              const distinctBranches = Array.from(
+                new Set(
+                  group.items
+                    .map((item: any) =>
+                      typeof item.branch === "string" ? item.branch.trim() : ""
+                    )
+                    .filter((branch: string) => branch.length > 0)
+                )
+              );
+              const quickStartBranch =
+                distinctBranches.length === 1 ? distinctBranches[0] : undefined;
               return (
               <div key={group.repository}>
                 <div className="flex items-center justify-between gap-2 px-2 py-1 text-sm text-black">

--- a/components/Layouts/ChatHistoryPanel.tsx
+++ b/components/Layouts/ChatHistoryPanel.tsx
@@ -9,6 +9,7 @@ import {
   MoreHorizontal,
   ChevronDown,
   ChevronUp,
+  Plus,
 } from "lucide-react";
 import Image from "next/image";
 import { toast } from "@/components/ui/sonner";
@@ -516,6 +517,24 @@ export function ChatHistoryPanel() {
     });
   }, []);
 
+  const handleRepoQuickStart = useCallback(
+    (repository: string, branch?: string, event?: React.MouseEvent) => {
+      event?.stopPropagation();
+      const repoName = repository?.trim();
+      if (!repoName || repoName === "No repository") {
+        toast.error("Repository is not available for quick start");
+        return;
+      }
+
+      const params = new URLSearchParams({ repo: repoName });
+      if (branch?.trim()) {
+        params.set("branch", branch.trim());
+      }
+      router.push(`/newchat?${params.toString()}`);
+    },
+    [router]
+  );
+
   return (
     <div className="flex flex-col h-full">
       {/* Header with Search Icon */}
@@ -570,7 +589,11 @@ export function ChatHistoryPanel() {
               </p>
             </div>
           ) : (
-            groupedItems.map((group) => (
+            groupedItems.map((group) => {
+              const quickStartBranch = group.items.find(
+                (item: any) => item.branch && String(item.branch).trim().length > 0
+              )?.branch as string | undefined;
+              return (
               <div key={group.repository}>
                 <div className="flex items-center justify-between gap-2 px-2 py-1 text-sm text-black">
                   <div className="flex items-center gap-2 min-w-0">
@@ -589,23 +612,40 @@ export function ChatHistoryPanel() {
                       {getRepositoryDisplayName(group.repository)}
                     </span>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-4 w-4 shrink-0"
-                    onClick={() => toggleRepository(group.repository)}
-                    aria-label={
-                      expandedRepositories.has(group.repository)
-                        ? `Collapse ${group.repository}`
-                        : `Expand ${group.repository}`
-                    }
-                  >
-                    {expandedRepositories.has(group.repository) ? (
-                      <ChevronUp className="h-3.5 w-3.5" />
-                    ) : (
-                      <ChevronDown className="h-3.5 w-3.5" />
-                    )}
-                  </Button>
+                  <div className="flex items-center gap-0.5 shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-4 w-4"
+                      onClick={(event) =>
+                        handleRepoQuickStart(
+                          group.repository,
+                          quickStartBranch,
+                          event
+                        )
+                      }
+                      aria-label={`Quick start ${group.repository}`}
+                    >
+                      <Plus className="h-3.5 w-3.5 text-[#B6E343]" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-4 w-4"
+                      onClick={() => toggleRepository(group.repository)}
+                      aria-label={
+                        expandedRepositories.has(group.repository)
+                          ? `Collapse ${group.repository}`
+                          : `Expand ${group.repository}`
+                      }
+                    >
+                      {expandedRepositories.has(group.repository) ? (
+                        <ChevronUp className="h-3.5 w-3.5" />
+                      ) : (
+                        <ChevronDown className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
                 </div>
 
                 {expandedRepositories.has(group.repository) &&
@@ -764,7 +804,8 @@ export function ChatHistoryPanel() {
                   );
                 })}
               </div>
-            ))
+            );
+            })
           )}
         </div>
       </ScrollArea>


### PR DESCRIPTION
Added direct repo-folder '+' quick-start action.
**Behavior:** clicking + on a repo group now routes directly to /newchat?repo=<repo> and includes branch=<branch> when available from that group.

Added URL-based repo/branch hydration in newchat:

- Reads repo and branch from query params.
- Auto-matches repo from linked repositories and sets selectedRepo.
- Fetches branches and resolves selectedBranch with fallback order:
   1. URL branch (if valid),
   2. repo default_branch,
   3. main,
   4. first available fetched branch.
- Handles invalid/missing repo or branch with safe fallbacks and toast.
- Autofocuses the idea textarea after prefill.

<img width="1920" height="1007" alt="Screenshot 2026-04-30 at 5 13 18 PM" src="https://github.com/user-attachments/assets/dad40b1e-3b56-4e36-be99-bead4021737c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added Quick Start capability with URL parameter support to pre-populate repository and branch selections when creating new chats, including intelligent resolution and fallback logic
* Added Quick Start button in the chat history panel for fast new chat creation with the current repository and branch context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->