### PR TITLE
fixed high vanta vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   },
   "pnpm": {
     "overrides": {
+      "minimatch@>=9.0.0 <9.0.7": "9.0.9",
       "form-data": "^4.0.4",
       "glob": "10.5.0",
       "mdast-util-to-hast": "13.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: 1.13.5
+  minimatch@>=9.0.0 <9.0.7: 9.0.9
   form-data: ^4.0.4
   glob: 10.5.0
   mdast-util-to-hast: 13.2.1
@@ -4138,10 +4138,6 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -7539,7 +7535,7 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.3
+      minimatch: 9.0.9
       semver: 7.7.3
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
@@ -9749,10 +9745,6 @@ snapshots:
       brace-expansion: 2.0.3
 
   minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 2.0.3
-
-  minimatch@9.0.3:
     dependencies:
       brace-expansion: 2.0.3
 


### PR DESCRIPTION
Patch minimatch transitive dependency to address CVE-2026-27903.

Add a pnpm override forcing minimatch versions in the vulnerable range (>=9.0.0 <9.0.7) to 9.0.9, and regenerate pnpm-lock.yaml to ensure no vulnerable minimatch 9.0.x entries remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version override to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->