### PR TITLE
Deploy staging from staging branch

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - staging
 
 env:
   PROJECT_ID: ${{ secrets.STAGE_GCLOUD_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Change the staging deployment workflow push trigger from `main` to `staging`.

## Test plan
- Verified the branch diff contains only `.github/workflows/deploy-staging.yaml`.
- Checked linter diagnostics for the edited workflow file.


Made with [Cursor](https://cursor.com)