### PR TITLE
Feat/cli auth integrations - Add frontend handoff for Potpie CLI browser login

### DIFF
--- a/app/(auth)/cli-success/page.tsx
+++ b/app/(auth)/cli-success/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import {
+  cliSuccessCopy,
+  normalizeCliAuthProvider,
+} from "@/lib/auth/cli-success";
+
+export default function CliSuccessPage() {
+  const searchParams = useSearchParams();
+  const provider = normalizeCliAuthProvider(searchParams.get("provider"));
+  const { title, body } = cliSuccessCopy(provider);
+
+  return (
+    <div className="relative flex h-screen w-full items-center justify-center bg-[#022D2C] px-6 font-sans">
+      <div className="max-w-md rounded-2xl bg-[#FFF9F5] p-8 text-center shadow-lg">
+        <h1 className="text-2xl font-medium text-[#022D2C]">{title}</h1>
+        <p className="mt-3 text-base text-[#656969]">{body}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/cli-success/page.tsx
+++ b/app/(auth)/cli-success/page.tsx
@@ -7,33 +7,67 @@ import {
   normalizeCliAuthProvider,
 } from "@/lib/auth/cli-success";
 
-function CliSuccessContent() {
-  const searchParams = useSearchParams();
-  const provider = normalizeCliAuthProvider(searchParams.get("provider"));
-  const { title, body } = cliSuccessCopy(provider);
-
+function PotpieLogo() {
   return (
-    <div className="relative flex h-screen w-full items-center justify-center bg-[#022D2C] px-6 font-sans">
-      <div className="max-w-md rounded-2xl bg-[#FFF9F5] p-8 text-center shadow-lg">
-        <h1 className="text-2xl font-medium text-[#022D2C]">{title}</h1>
-        <p className="mt-3 text-base text-[#656969]">{body}</p>
+    <svg
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-10 w-10"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M80.1337 9.02135C90.9927 -1.7528 108.499 -1.7528 119.358 9.02135C125.146 14.7628 133.157 17.6802 141.278 17.005C153.993 15.9455 165.435 23.612 169.689 35.0315L107.932 70.2676L102.929 73.1775C98.5836 75.7069 95.8808 80.3255 95.808 85.3544L95.448 110.204V117.561C95.448 122.859 98.3505 127.75 103.037 130.275L159.639 160.781C154.725 163.594 150.731 167.869 148.269 173.092C141.746 186.933 125.295 192.924 111.41 186.519C104.008 183.102 95.4835 183.102 88.0818 186.519C74.1963 192.924 57.745 186.933 51.2229 173.092C47.7468 165.717 41.2163 160.233 33.353 158.087C18.6001 154.066 9.84703 138.893 13.7409 124.094C15.8161 116.207 14.3359 107.806 9.68941 101.105C0.973649 88.533 4.01321 71.2824 16.5007 62.4519C23.1571 57.7438 27.4194 50.3571 28.1646 42.2354C29.5636 26.9994 42.9744 15.7365 58.2132 17.005C66.3349 17.6802 74.3455 14.7628 80.1337 9.02135Z"
+        fill="#B6E343"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M113.221 81.9871L113.335 81.7632L113.447 81.5879C113.355 81.7147 113.279 81.8453 113.221 81.9871ZM173.455 142.343C174.454 142.884 174.954 143.155 175.219 143.6C175.435 143.965 175.528 144.482 175.452 144.899C175.36 145.409 175.022 145.795 174.348 146.568C173.294 147.776 172.132 148.898 170.872 149.916C170.219 150.444 169.892 150.708 169.416 150.87C169.031 151.001 168.511 151.049 168.109 150.992C167.612 150.921 167.183 150.69 166.324 150.227L108.927 119.312C108.272 118.958 107.864 118.271 107.864 117.525V110.168C107.864 108.635 109.498 107.658 110.844 108.385L173.455 142.343Z"
+        fill="#B6E343"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M173.18 53.712C174.026 51.3567 174.449 50.1791 174.18 49.5137C173.946 48.9372 173.444 48.5132 172.836 48.3807C172.135 48.2278 171.045 48.8431 168.867 50.0738L114.084 81.0161C113.819 81.1691 113.608 81.3631 113.446 81.5869L113.334 81.7623L113.22 81.9861C113.093 82.292 113.043 82.624 113.069 82.9449L113.079 83.0381C113.157 83.6574 113.515 84.2431 114.149 84.5752L172.391 117.478C173.48 118.093 174.025 118.401 174.376 118.324C174.679 118.258 174.931 118.046 175.047 117.758C175.182 117.425 174.971 116.836 174.548 115.659L163.111 83.7977C162.975 83.4209 162.908 83.2325 162.881 83.0392C162.857 82.8676 162.857 82.6936 162.881 82.5221C162.908 82.3287 162.975 82.1403 163.111 81.7635L173.18 53.712Z"
+        fill="#B6E343"
+      />
+    </svg>
+  );
+}
+
+function CliSuccessShell({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="fixed inset-0 flex min-h-screen items-center justify-center bg-white px-6">
+      <div
+        className="flex max-w-[360px] flex-col items-center gap-4 text-center"
+        role="region"
+        aria-label="Authentication successful"
+      >
+        <div className="mb-1">
+          <PotpieLogo />
+        </div>
+        <h1 className="text-[18px] font-semibold text-[#111111]">{title}</h1>
+        <p className="text-[13px] leading-[1.5] text-[#666666]">{body}</p>
       </div>
     </div>
   );
 }
 
+function CliSuccessContent() {
+  const searchParams = useSearchParams();
+  const provider = normalizeCliAuthProvider(searchParams.get("provider"));
+  const { title, body } = cliSuccessCopy(provider);
+
+  return <CliSuccessShell title={title} body={body} />;
+}
+
 export default function CliSuccessPage() {
   return (
     <Suspense
-      fallback={
-        <div className="relative flex h-screen w-full items-center justify-center bg-[#022D2C] px-6 font-sans">
-          <div className="max-w-md rounded-2xl bg-[#FFF9F5] p-8 text-center shadow-lg">
-            <h1 className="text-2xl font-medium text-[#022D2C]">
-              Finishing sign in...
-            </h1>
-          </div>
-        </div>
-      }
+      fallback={<CliSuccessShell title="Finishing sign in..." body="" />}
     >
       <CliSuccessContent />
     </Suspense>

--- a/app/(auth)/cli-success/page.tsx
+++ b/app/(auth)/cli-success/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   cliSuccessCopy,
   normalizeCliAuthProvider,
 } from "@/lib/auth/cli-success";
 
-export default function CliSuccessPage() {
+function CliSuccessContent() {
   const searchParams = useSearchParams();
   const provider = normalizeCliAuthProvider(searchParams.get("provider"));
   const { title, body } = cliSuccessCopy(provider);
@@ -18,5 +19,23 @@ export default function CliSuccessPage() {
         <p className="mt-3 text-base text-[#656969]">{body}</p>
       </div>
     </div>
+  );
+}
+
+export default function CliSuccessPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="relative flex h-screen w-full items-center justify-center bg-[#022D2C] px-6 font-sans">
+          <div className="max-w-md rounded-2xl bg-[#FFF9F5] p-8 text-center shadow-lg">
+            <h1 className="text-2xl font-medium text-[#022D2C]">
+              Finishing sign in...
+            </h1>
+          </div>
+        </div>
+      }
+    >
+      <CliSuccessContent />
+    </Suspense>
   );
 }

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -3,7 +3,14 @@ import { useAuthContext } from "@/contexts/AuthContext";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect } from "react";
 import AuthService from "@/services/AuthService";
+import {
+  CliAuthError,
+  completeCliAuthentication,
+  isValidCliCallbackUrl,
+} from "@/lib/auth/cli-callback";
+import { cliSuccessPath } from "@/lib/auth/cli-success";
 import { buildVSCodeCallbackUrl } from "@/lib/auth/vscode-callback";
+import { toast } from "@/components/ui/sonner";
 
 export default function AuthLayout({
   children,
@@ -16,10 +23,29 @@ export default function AuthLayout({
   const redirectUrl = searchParams.get("redirect");
   const redirect_uri = searchParams.get("redirect_uri");
   const agent_id = searchParams.get("agent_id");
+  const cliCallbackRaw = searchParams.get("cli_callback");
+  const cliCallback = isValidCliCallbackUrl(cliCallbackRaw)
+    ? cliCallbackRaw!.trim()
+    : null;
   const router = useRouter();
 
   useEffect(() => {
     if (user) {
+      if (cliCallback) {
+        completeCliAuthentication(cliCallback)
+          .then(() => {
+            router.replace(cliSuccessPath("potpie"));
+          })
+          .catch((error: unknown) => {
+            const message =
+              error instanceof CliAuthError
+                ? error.message
+                : "CLI authentication failed. Please try again.";
+            toast.error(message);
+          });
+        return;
+      }
+
       // Handle VSCode authentication flow
       if (source === "vscode") {
         const fetchCustomTokenWithRetry = (): Promise<string | null> =>
@@ -72,7 +98,8 @@ export default function AuthLayout({
       if (
         !window.location.pathname.startsWith("/onboarding") &&
         !window.location.pathname.startsWith("/sign-up") &&
-        !window.location.pathname.startsWith("/link-github")
+        !window.location.pathname.startsWith("/link-github") &&
+        !window.location.pathname.startsWith("/cli-success")
       ) {
         if (process.env.NODE_ENV === "development") {
           console.log(
@@ -83,7 +110,7 @@ export default function AuthLayout({
         router.push(redirectUrl ? decodeURIComponent(redirectUrl) : "/");
       }
     }
-  }, [user, source, redirectUrl, redirect_uri, agent_id, router]);
+  }, [user, source, redirectUrl, redirect_uri, agent_id, cliCallback, router]);
 
   return (
     <div className="min-h-screen w-full grid place-items-center">

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -26,6 +26,12 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { LinkProviderDialog } from "@/components/auth/LinkProviderDialog";
 import type { SSOLoginResponse } from "@/types/auth";
 import { authClient } from "@/lib/sso/unified-auth";
+import {
+  CliAuthError,
+  completeCliAuthentication,
+  isValidCliCallbackUrl,
+} from "@/lib/auth/cli-callback";
+import { cliSuccessPath } from "@/lib/auth/cli-success";
 import { buildVSCodeCallbackUrl } from "@/lib/auth/vscode-callback";
 
 export default function Signin() {
@@ -35,6 +41,10 @@ export default function Signin() {
   const agent_id = searchParams.get("agent_id");
   const redirectUrl = searchParams.get("redirect");
   const redirect_uri = searchParams.get("redirect_uri");
+  const cliCallbackRaw = searchParams.get("cli_callback");
+  const cliCallback = isValidCliCallbackUrl(cliCallbackRaw)
+    ? cliCallbackRaw!.trim()
+    : null;
 
   // SSO state
   const [linkingData, setLinkingData] = React.useState<SSOLoginResponse | null>(
@@ -44,6 +54,28 @@ export default function Signin() {
   const [showPassword, setShowPassword] = React.useState(false);
   const [keepLoggedIn, setKeepLoggedIn] = React.useState(false);
   const [currentTestimonial, setCurrentTestimonial] = React.useState(0);
+  const [cliAuthPending, setCliAuthPending] = React.useState(false);
+
+  const tryCompleteCliAuth = React.useCallback(async (): Promise<boolean> => {
+    if (!cliCallback) {
+      return false;
+    }
+    setCliAuthPending(true);
+    try {
+      await completeCliAuthentication(cliCallback);
+      router.replace(cliSuccessPath("potpie"));
+      return true;
+    } catch (error: unknown) {
+      const message =
+        error instanceof CliAuthError
+          ? error.message
+          : "CLI authentication failed. Please try again.";
+      toast.error(message);
+      return true;
+    } finally {
+      setCliAuthPending(false);
+    }
+  }, [cliCallback, router]);
 
   // Extract agent_id from redirect URL if present
   let redirectAgent_id = "";
@@ -80,10 +112,13 @@ export default function Signin() {
 
   const googleProvider = new GoogleAuthProvider();
 
-  const handleExternalRedirect = (
+  const handleExternalRedirect = async (
     token: string,
     customToken?: string | null,
   ) => {
+    if (await tryCompleteCliAuth()) {
+      return;
+    }
     if (finalAgent_id) {
       window.location.href = `/shared-agent?agent_id=${finalAgent_id}`;
     } else if (source === "vscode") {
@@ -126,14 +161,18 @@ export default function Signin() {
             return;
           }
 
+          if (await tryCompleteCliAuth()) {
+            return;
+          }
+
           if (source === "vscode") {
             if (userSignup.token) {
               const customToken =
                 userSignup.customToken ?? (await AuthService.getCustomToken());
-              handleExternalRedirect(userSignup.token, customToken);
+              await handleExternalRedirect(userSignup.token, customToken);
             }
           } else if (finalAgent_id) {
-            handleExternalRedirect("");
+            await handleExternalRedirect("");
           } else {
             router.push("/newchat");
           }
@@ -270,15 +309,19 @@ export default function Signin() {
               return;
             }
 
+            if (await tryCompleteCliAuth()) {
+              return;
+            }
+
             if (source === "vscode") {
               if (userSignup.token) {
                 const customToken =
                   userSignup.customToken ??
                   (await AuthService.getCustomToken());
-                handleExternalRedirect(userSignup.token, customToken);
+                await handleExternalRedirect(userSignup.token, customToken);
               }
             } else if (finalAgent_id) {
-              handleExternalRedirect("");
+              await handleExternalRedirect("");
             } else {
               window.location.href = "/newchat";
             }
@@ -381,12 +424,16 @@ export default function Signin() {
             return;
           }
 
+          if (await tryCompleteCliAuth()) {
+            return;
+          }
+
           if (source === "vscode") {
             const customToken =
               response.firebase_token ?? (await AuthService.getCustomToken());
-            handleExternalRedirect(firebaseIdToken, customToken);
+            await handleExternalRedirect(firebaseIdToken, customToken);
           } else if (finalAgent_id) {
-            handleExternalRedirect("");
+            await handleExternalRedirect("");
           } else {
             window.location.href = "/newchat";
           }
@@ -406,7 +453,10 @@ export default function Signin() {
       });
   };
 
-  const handleSSOLinked = () => {
+  const handleSSOLinked = async () => {
+    if (await tryCompleteCliAuth()) {
+      return;
+    }
     if (source === "vscode") {
       const user = auth.currentUser;
       if (!user) {
@@ -430,6 +480,21 @@ export default function Signin() {
       router.push("/newchat");
     }
   };
+
+  if (cliAuthPending && cliCallback) {
+    return (
+      <div className="relative flex h-screen w-full items-center justify-center bg-[#022D2C] px-6 font-sans">
+        <div className="max-w-md rounded-2xl bg-[#FFF9F5] p-8 text-center shadow-lg">
+          <h1 className="text-2xl font-medium text-[#022D2C]">
+            Completing CLI sign-in
+          </h1>
+          <p className="mt-3 text-base text-[#656969]">
+            Sending your session to the CLI. This may take a moment…
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="relative h-screen w-full font-sans bg-[#022D2C] overflow-hidden">
@@ -487,6 +552,13 @@ export default function Signin() {
                   <h1 className="text-center text-2xl font-medium text-[#022D2C]">
                     Sign in to your account
                   </h1>
+                  {cliCallback && (
+                    <p className="text-center text-sm text-[#656969]">
+                      {cliAuthPending
+                        ? "Completing CLI authentication…"
+                        : "Sign in to connect the Potpie CLI."}
+                    </p>
+                  )}
                 </div>
 
                 {/* Social buttons (interactive, styled to match) */}

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -27,11 +27,8 @@ import { LinkProviderDialog } from "@/components/auth/LinkProviderDialog";
 import type { SSOLoginResponse } from "@/types/auth";
 import { authClient } from "@/lib/sso/unified-auth";
 import {
-  CliAuthError,
-  completeCliAuthentication,
   isValidCliCallbackUrl,
 } from "@/lib/auth/cli-callback";
-import { cliSuccessPath } from "@/lib/auth/cli-success";
 import { buildVSCodeCallbackUrl } from "@/lib/auth/vscode-callback";
 
 export default function Signin() {
@@ -54,28 +51,14 @@ export default function Signin() {
   const [showPassword, setShowPassword] = React.useState(false);
   const [keepLoggedIn, setKeepLoggedIn] = React.useState(false);
   const [currentTestimonial, setCurrentTestimonial] = React.useState(0);
-  const [cliAuthPending, setCliAuthPending] = React.useState(false);
 
   const tryCompleteCliAuth = React.useCallback(async (): Promise<boolean> => {
     if (!cliCallback) {
       return false;
     }
-    setCliAuthPending(true);
-    try {
-      await completeCliAuthentication(cliCallback);
-      router.replace(cliSuccessPath("potpie"));
-      return true;
-    } catch (error: unknown) {
-      const message =
-        error instanceof CliAuthError
-          ? error.message
-          : "CLI authentication failed. Please try again.";
-      toast.error(message);
-      return true;
-    } finally {
-      setCliAuthPending(false);
-    }
-  }, [cliCallback, router]);
+    // Auth layout owns CLI completion to avoid duplicate POSTs/toasts.
+    return true;
+  }, [cliCallback]);
 
   // Extract agent_id from redirect URL if present
   let redirectAgent_id = "";
@@ -481,21 +464,6 @@ export default function Signin() {
     }
   };
 
-  if (cliAuthPending && cliCallback) {
-    return (
-      <div className="relative flex h-screen w-full items-center justify-center bg-[#022D2C] px-6 font-sans">
-        <div className="max-w-md rounded-2xl bg-[#FFF9F5] p-8 text-center shadow-lg">
-          <h1 className="text-2xl font-medium text-[#022D2C]">
-            Completing CLI sign-in
-          </h1>
-          <p className="mt-3 text-base text-[#656969]">
-            Sending your session to the CLI. This may take a moment…
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="relative h-screen w-full font-sans bg-[#022D2C] overflow-hidden">
       {/* Background vector */}
@@ -554,9 +522,7 @@ export default function Signin() {
                   </h1>
                   {cliCallback && (
                     <p className="text-center text-sm text-[#656969]">
-                      {cliAuthPending
-                        ? "Completing CLI authentication…"
-                        : "Sign in to connect the Potpie CLI."}
+                      Sign in to connect the Potpie CLI.
                     </p>
                   )}
                 </div>

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -26,9 +26,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { LinkProviderDialog } from "@/components/auth/LinkProviderDialog";
 import type { SSOLoginResponse } from "@/types/auth";
 import { authClient } from "@/lib/sso/unified-auth";
-import {
-  isValidCliCallbackUrl,
-} from "@/lib/auth/cli-callback";
+import { isValidCliCallbackUrl } from "@/lib/auth/cli-callback";
 import { buildVSCodeCallbackUrl } from "@/lib/auth/vscode-callback";
 
 export default function Signin() {
@@ -59,6 +57,16 @@ export default function Signin() {
     // Auth layout owns CLI completion to avoid duplicate POSTs/toasts.
     return true;
   }, [cliCallback]);
+
+  const appendCliCallback = React.useCallback(
+    (params: URLSearchParams) => {
+      if (cliCallback) {
+        params.set("cli_callback", cliCallback);
+      }
+      return params;
+    },
+    [cliCallback],
+  );
 
   // Extract agent_id from redirect URL if present
   let redirectAgent_id = "";
@@ -131,14 +139,16 @@ export default function Signin() {
             ).toLowerCase();
             const prompt = urlSearchParams.get("prompt") || "";
 
-            const onboardingParams = new URLSearchParams({
-              uid: user.uid,
-              ...(user.email && { email: user.email }),
-              ...(user.displayName && { name: user.displayName }),
-              ...(plan && { plan }),
-              ...(prompt && { prompt }),
-              ...(finalAgent_id && { agent_id: finalAgent_id }),
-            });
+            const onboardingParams = appendCliCallback(
+              new URLSearchParams({
+                uid: user.uid,
+                ...(user.email && { email: user.email }),
+                ...(user.displayName && { name: user.displayName }),
+                ...(plan && { plan }),
+                ...(prompt && { prompt }),
+                ...(finalAgent_id && { agent_id: finalAgent_id }),
+              }),
+            );
 
             window.location.href = `/onboarding?${onboardingParams.toString()}`;
             return;
@@ -244,7 +254,7 @@ export default function Signin() {
               ).toLowerCase();
               const prompt = urlSearchParams.get("prompt") || "";
 
-              const onboardingParams = new URLSearchParams();
+              const onboardingParams = appendCliCallback(new URLSearchParams());
               if (result.user.uid)
                 onboardingParams.append("uid", result.user.uid);
               if (result.user.email)
@@ -276,7 +286,7 @@ export default function Signin() {
               ).toLowerCase();
               const prompt = urlSearchParams.get("prompt") || "";
 
-              const onboardingParams = new URLSearchParams();
+              const onboardingParams = appendCliCallback(new URLSearchParams());
               if (result.user.uid)
                 onboardingParams.append("uid", result.user.uid);
               if (result.user.email)
@@ -358,7 +368,8 @@ export default function Signin() {
               sub: user.uid,
               name: user.displayName || "",
               given_name: user.displayName?.split(" ")[0] || "",
-              family_name: user.displayName?.split(" ").slice(1).join(" ") || "",
+              family_name:
+                user.displayName?.split(" ").slice(1).join(" ") || "",
               picture: user.photoURL || "",
             },
           );
@@ -394,14 +405,16 @@ export default function Signin() {
             const onboardingName =
               response.display_name || user.displayName || "";
 
-            const onboardingParams = new URLSearchParams({
-              ...(onboardingUid && { uid: onboardingUid }),
-              ...(onboardingEmail && { email: onboardingEmail }),
-              ...(onboardingName && { name: onboardingName }),
-              ...(plan && { plan }),
-              ...(prompt && { prompt }),
-              ...(finalAgent_id && { agent_id: finalAgent_id }),
-            });
+            const onboardingParams = appendCliCallback(
+              new URLSearchParams({
+                ...(onboardingUid && { uid: onboardingUid }),
+                ...(onboardingEmail && { email: onboardingEmail }),
+                ...(onboardingName && { name: onboardingName }),
+                ...(plan && { plan }),
+                ...(prompt && { prompt }),
+                ...(finalAgent_id && { agent_id: finalAgent_id }),
+              }),
+            );
 
             window.location.href = `/onboarding?${onboardingParams.toString()}`;
             return;
@@ -502,8 +515,6 @@ export default function Signin() {
                   priority
                 />
               </Link>
-
-
             </div>
 
             {/* Form content */}
@@ -535,8 +546,18 @@ export default function Signin() {
                     className="inline-flex h-10 w-full items-center justify-center rounded-lg border border-[#EBEBEB] bg-white hover:bg-black/[0.02] transition-colors"
                     aria-label="Continue with GitHub"
                   >
-                    <svg height="20" width="20" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
-                      <path fill="#24292f" fillRule="evenodd" clipRule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" />
+                    <svg
+                      height="20"
+                      width="20"
+                      viewBox="0 0 98 96"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        fill="#24292f"
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+                      />
                     </svg>
                   </button>
                   <button

--- a/lib/auth/cli-callback-url.ts
+++ b/lib/auth/cli-callback-url.ts
@@ -10,7 +10,7 @@ export function isValidCliCallbackUrl(raw: string | null | undefined): boolean {
     if (url.protocol !== "http:") {
       return false;
     }
-    if (url.hostname !== "localhost") {
+    if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
       return false;
     }
     if (url.username || url.password) {

--- a/lib/auth/cli-callback-url.ts
+++ b/lib/auth/cli-callback-url.ts
@@ -1,0 +1,23 @@
+/**
+ * CLI auth callback URL validation (no Firebase dependency).
+ */
+export function isValidCliCallbackUrl(raw: string | null | undefined): boolean {
+  if (!raw?.trim()) {
+    return false;
+  }
+  try {
+    const url = new URL(raw.trim());
+    if (url.protocol !== "http:") {
+      return false;
+    }
+    if (url.hostname !== "localhost") {
+      return false;
+    }
+    if (url.username || url.password) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lib/auth/cli-callback.test.ts
+++ b/lib/auth/cli-callback.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isValidCliCallbackUrl } from "./cli-callback-url";
+
+describe("isValidCliCallbackUrl", () => {
+  it("accepts http://localhost with port", () => {
+    expect(isValidCliCallbackUrl("http://localhost:9123")).toBe(true);
+  });
+
+  it("rejects non-localhost hosts", () => {
+    expect(isValidCliCallbackUrl("http://127.0.0.1:9123")).toBe(false);
+    expect(isValidCliCallbackUrl("https://localhost:9123")).toBe(false);
+    expect(isValidCliCallbackUrl("http://evil.example:9123")).toBe(false);
+  });
+
+  it("rejects empty and malformed URLs", () => {
+    expect(isValidCliCallbackUrl(null)).toBe(false);
+    expect(isValidCliCallbackUrl("not-a-url")).toBe(false);
+  });
+});

--- a/lib/auth/cli-callback.test.ts
+++ b/lib/auth/cli-callback.test.ts
@@ -1,13 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { completeCliAuthentication } from "./cli-callback";
 import { isValidCliCallbackUrl } from "./cli-callback-url";
 
+vi.mock("@/configs/Firebase-config", () => ({
+  auth: {
+    currentUser: {
+      getIdToken: vi.fn().mockResolvedValue("firebase-id-token"),
+    },
+  },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.pushState({}, "", "/");
+  delete process.env.NEXT_PUBLIC_BASE_URL;
+  delete process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+});
+
 describe("isValidCliCallbackUrl", () => {
-  it("accepts http://localhost with port", () => {
+  it("accepts http loopback hosts with port", () => {
     expect(isValidCliCallbackUrl("http://localhost:9123")).toBe(true);
+    expect(isValidCliCallbackUrl("http://127.0.0.1:9123")).toBe(true);
   });
 
   it("rejects non-localhost hosts", () => {
-    expect(isValidCliCallbackUrl("http://127.0.0.1:9123")).toBe(false);
     expect(isValidCliCallbackUrl("https://localhost:9123")).toBe(false);
     expect(isValidCliCallbackUrl("http://evil.example:9123")).toBe(false);
   });
@@ -15,5 +31,52 @@ describe("isValidCliCallbackUrl", () => {
   it("rejects empty and malformed URLs", () => {
     expect(isValidCliCallbackUrl(null)).toBe(false);
     expect(isValidCliCallbackUrl("not-a-url")).toBe(false);
+  });
+});
+
+describe("completeCliAuthentication", () => {
+  it("does not POST to the CLI callback without state", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.NEXT_PUBLIC_BASE_URL = "https://api.potpie.example";
+    process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "firebase-key";
+    window.history.pushState({}, "", "/sign-in?cli_callback=http://localhost:9123/cb");
+
+    await expect(
+      completeCliAuthentication("http://localhost:9123/cb"),
+    ).rejects.toThrow("Missing CLI auth state.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("echoes state in the CLI callback body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ customToken: "header.payload.signature" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.NEXT_PUBLIC_BASE_URL = "https://api.potpie.example";
+    process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "firebase-key";
+    window.history.pushState(
+      {},
+      "",
+      "/sign-in?cli_callback=http://127.0.0.1:9123/random-path&state=state-123",
+    );
+
+    await expect(
+      completeCliAuthentication("http://127.0.0.1:9123/random-path"),
+    ).resolves.toBe("header.payload.signature");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const callbackBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(callbackBody).toEqual({
+      custom_token: "header.payload.signature",
+      firebase_api_key: "firebase-key",
+      state: "state-123",
+    });
   });
 });

--- a/lib/auth/cli-callback.test.ts
+++ b/lib/auth/cli-callback.test.ts
@@ -79,4 +79,40 @@ describe("completeCliAuthentication", () => {
       state: "state-123",
     });
   });
+
+  it("deduplicates concurrent runs for the same callback+state", async () => {
+    let customTokenCalls = 0;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        customTokenCalls += 1;
+        await Promise.resolve();
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({ customToken: "header.payload.signature" }),
+        };
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.NEXT_PUBLIC_BASE_URL = "https://api.potpie.example";
+    process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "firebase-key";
+    window.history.pushState(
+      {},
+      "",
+      "/sign-in?cli_callback=http://127.0.0.1:9123/random-path&state=state-456",
+    );
+
+    const [first, second] = await Promise.all([
+      completeCliAuthentication("http://127.0.0.1:9123/random-path"),
+      completeCliAuthentication("http://127.0.0.1:9123/random-path"),
+    ]);
+
+    expect(first).toBe("header.payload.signature");
+    expect(second).toBe("header.payload.signature");
+    expect(customTokenCalls).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/lib/auth/cli-callback.ts
+++ b/lib/auth/cli-callback.ts
@@ -1,0 +1,90 @@
+import { auth } from "@/configs/Firebase-config";
+import { isValidCliCallbackUrl } from "@/lib/auth/cli-callback-url";
+
+export { isValidCliCallbackUrl };
+
+export class CliAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliAuthError";
+  }
+}
+
+/**
+ * Exchange the browser Firebase session for a Firebase custom token and POST it
+ * to the CLI callback with the public Firebase Web API key needed for REST
+ * exchange. The Firebase ID token only travels to the Potpie backend.
+ */
+export async function completeCliAuthentication(
+  cliCallback: string,
+): Promise<string> {
+  if (!isValidCliCallbackUrl(cliCallback)) {
+    throw new CliAuthError("Invalid CLI callback URL.");
+  }
+
+  const user = auth.currentUser;
+  if (!user) {
+    throw new CliAuthError("Not signed in. Please sign in and try again.");
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  if (!baseUrl?.trim()) {
+    throw new CliAuthError("API URL is not configured.");
+  }
+
+  const firebaseIdToken = await user.getIdToken();
+  if (!firebaseIdToken) {
+    throw new CliAuthError("Failed to obtain Firebase ID token.");
+  }
+  const firebaseApiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+  if (!firebaseApiKey?.trim()) {
+    throw new CliAuthError("Firebase API key is not configured.");
+  }
+
+  const createResponse = await fetch(`${baseUrl}/api/v1/auth/custom-token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${firebaseIdToken}`,
+      "Content-Type": "application/json",
+    },
+    body: "{}",
+  });
+
+  if (!createResponse.ok) {
+    let detail = "Failed to create CLI session token.";
+    try {
+      const body = await createResponse.json();
+      detail =
+        body?.detail ||
+        body?.error ||
+        body?.message ||
+        detail;
+    } catch {
+      /* ignore parse errors */
+    }
+    throw new CliAuthError(detail);
+  }
+
+  const payload = (await createResponse.json()) as { customToken?: string };
+  const customToken = payload.customToken?.trim();
+  if (!customToken || customToken.split(".").length !== 3) {
+    throw new CliAuthError("Invalid custom token returned from server.");
+  }
+
+  const callbackResponse = await fetch(cliCallback.trim(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      custom_token: customToken,
+      firebase_api_key: firebaseApiKey.trim(),
+    }),
+  });
+
+  if (!callbackResponse.ok) {
+    throw new CliAuthError(
+      "Failed to send session token to the CLI. Ensure the CLI is waiting for authentication.",
+    );
+  }
+
+  return customToken;
+}

--- a/lib/auth/cli-callback.ts
+++ b/lib/auth/cli-callback.ts
@@ -21,6 +21,10 @@ export async function completeCliAuthentication(
   if (!isValidCliCallbackUrl(cliCallback)) {
     throw new CliAuthError("Invalid CLI callback URL.");
   }
+  const state = getCliAuthStateFromUrl();
+  if (!state) {
+    throw new CliAuthError("Missing CLI auth state.");
+  }
 
   const user = auth.currentUser;
   if (!user) {
@@ -77,6 +81,7 @@ export async function completeCliAuthentication(
     body: JSON.stringify({
       custom_token: customToken,
       firebase_api_key: firebaseApiKey.trim(),
+      state,
     }),
   });
 
@@ -87,4 +92,11 @@ export async function completeCliAuthentication(
   }
 
   return customToken;
+}
+
+function getCliAuthStateFromUrl(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return new URLSearchParams(window.location.search).get("state")?.trim() || "";
 }

--- a/lib/auth/cli-callback.ts
+++ b/lib/auth/cli-callback.ts
@@ -10,6 +10,9 @@ export class CliAuthError extends Error {
   }
 }
 
+const inFlightCliAuthRuns = new Map<string, Promise<string>>();
+const completedCliAuthRuns = new Map<string, string>();
+
 /**
  * Exchange the browser Firebase session for a Firebase custom token and POST it
  * to the CLI callback with the public Firebase Web API key needed for REST
@@ -25,73 +28,86 @@ export async function completeCliAuthentication(
   if (!state) {
     throw new CliAuthError("Missing CLI auth state.");
   }
-
-  const user = auth.currentUser;
-  if (!user) {
-    throw new CliAuthError("Not signed in. Please sign in and try again.");
+  const runKey = buildCliAuthRunKey(cliCallback, state);
+  const completedToken = completedCliAuthRuns.get(runKey);
+  if (completedToken) {
+    return completedToken;
+  }
+  const existingRun = inFlightCliAuthRuns.get(runKey);
+  if (existingRun) {
+    return existingRun;
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  if (!baseUrl?.trim()) {
-    throw new CliAuthError("API URL is not configured.");
-  }
-
-  const firebaseIdToken = await user.getIdToken();
-  if (!firebaseIdToken) {
-    throw new CliAuthError("Failed to obtain Firebase ID token.");
-  }
-  const firebaseApiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
-  if (!firebaseApiKey?.trim()) {
-    throw new CliAuthError("Firebase API key is not configured.");
-  }
-
-  const createResponse = await fetch(`${baseUrl}/api/v1/auth/custom-token`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${firebaseIdToken}`,
-      "Content-Type": "application/json",
-    },
-    body: "{}",
-  });
-
-  if (!createResponse.ok) {
-    let detail = "Failed to create CLI session token.";
-    try {
-      const body = await createResponse.json();
-      detail =
-        body?.detail ||
-        body?.error ||
-        body?.message ||
-        detail;
-    } catch {
-      /* ignore parse errors */
+  const run = (async (): Promise<string> => {
+    const user = auth.currentUser;
+    if (!user) {
+      throw new CliAuthError("Not signed in. Please sign in and try again.");
     }
-    throw new CliAuthError(detail);
-  }
 
-  const payload = (await createResponse.json()) as { customToken?: string };
-  const customToken = payload.customToken?.trim();
-  if (!customToken || customToken.split(".").length !== 3) {
-    throw new CliAuthError("Invalid custom token returned from server.");
-  }
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+    if (!baseUrl?.trim()) {
+      throw new CliAuthError("API URL is not configured.");
+    }
 
-  const callbackResponse = await fetch(cliCallback.trim(), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      custom_token: customToken,
-      firebase_api_key: firebaseApiKey.trim(),
-      state,
-    }),
+    const firebaseIdToken = await user.getIdToken();
+    if (!firebaseIdToken) {
+      throw new CliAuthError("Failed to obtain Firebase ID token.");
+    }
+    const firebaseApiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+    if (!firebaseApiKey?.trim()) {
+      throw new CliAuthError("Firebase API key is not configured.");
+    }
+
+    const createResponse = await fetch(`${baseUrl}/api/v1/auth/custom-token`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${firebaseIdToken}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+
+    if (!createResponse.ok) {
+      let detail = "Failed to create CLI session token.";
+      try {
+        const body = await createResponse.json();
+        detail = body?.detail || body?.error || body?.message || detail;
+      } catch {
+        /* ignore parse errors */
+      }
+      throw new CliAuthError(detail);
+    }
+
+    const payload = (await createResponse.json()) as { customToken?: string };
+    const customToken = payload.customToken?.trim();
+    if (!customToken || customToken.split(".").length !== 3) {
+      throw new CliAuthError("Invalid custom token returned from server.");
+    }
+
+    const callbackResponse = await fetch(cliCallback.trim(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        custom_token: customToken,
+        firebase_api_key: firebaseApiKey.trim(),
+        state,
+      }),
+    });
+
+    if (!callbackResponse.ok) {
+      throw new CliAuthError(
+        "Failed to send session token to the CLI. Ensure the CLI is waiting for authentication.",
+      );
+    }
+
+    completedCliAuthRuns.set(runKey, customToken);
+    return customToken;
+  })().finally(() => {
+    inFlightCliAuthRuns.delete(runKey);
   });
 
-  if (!callbackResponse.ok) {
-    throw new CliAuthError(
-      "Failed to send session token to the CLI. Ensure the CLI is waiting for authentication.",
-    );
-  }
-
-  return customToken;
+  inFlightCliAuthRuns.set(runKey, run);
+  return run;
 }
 
 function getCliAuthStateFromUrl(): string {
@@ -99,4 +115,8 @@ function getCliAuthStateFromUrl(): string {
     return "";
   }
   return new URLSearchParams(window.location.search).get("state")?.trim() || "";
+}
+
+function buildCliAuthRunKey(cliCallback: string, state: string): string {
+  return `${cliCallback.trim()}::${state}`;
 }

--- a/lib/auth/cli-success.test.ts
+++ b/lib/auth/cli-success.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  cliSuccessCopy,
+  cliSuccessPath,
+  normalizeCliAuthProvider,
+} from "./cli-success";
+
+describe("cli-success helpers", () => {
+  it("normalizes provider query param", () => {
+    expect(normalizeCliAuthProvider("github")).toBe("github");
+    expect(normalizeCliAuthProvider("potpie")).toBe("potpie");
+    expect(normalizeCliAuthProvider(null)).toBe("potpie");
+    expect(normalizeCliAuthProvider("other")).toBe("potpie");
+  });
+
+  it("builds success path and copy", () => {
+    expect(cliSuccessPath("potpie")).toBe("/cli-success?provider=potpie");
+    expect(cliSuccessPath("github")).toBe("/cli-success?provider=github");
+    expect(cliSuccessCopy("potpie").body).toContain("return to your CLI");
+    expect(cliSuccessCopy("github").title).toBe("GitHub connected");
+  });
+});

--- a/lib/auth/cli-success.ts
+++ b/lib/auth/cli-success.ts
@@ -1,0 +1,32 @@
+/**
+ * CLI auth success page helpers (no Firebase dependency).
+ */
+
+export type CliAuthProvider = "potpie" | "github";
+
+export function normalizeCliAuthProvider(
+  raw: string | null | undefined,
+): CliAuthProvider {
+  const value = (raw || "potpie").trim().toLowerCase();
+  return value === "github" ? "github" : "potpie";
+}
+
+export function cliSuccessCopy(provider: CliAuthProvider): {
+  title: string;
+  body: string;
+} {
+  if (provider === "github") {
+    return {
+      title: "GitHub connected",
+      body: "Successfully logged in to GitHub. You may return to your CLI.",
+    };
+  }
+  return {
+    title: "Logged in to Potpie",
+    body: "Successfully logged in. You may return to your CLI.",
+  };
+}
+
+export function cliSuccessPath(provider: CliAuthProvider): string {
+  return `/cli-success?provider=${provider}`;
+}

--- a/lib/auth/cli-success.ts
+++ b/lib/auth/cli-success.ts
@@ -18,12 +18,12 @@ export function cliSuccessCopy(provider: CliAuthProvider): {
   if (provider === "github") {
     return {
       title: "GitHub connected",
-      body: "Successfully logged in to GitHub. You may return to your CLI.",
+      body: "Successfully connected GitHub for Potpie CLI. You can close this window and return to your terminal.",
     };
   }
   return {
-    title: "Logged in to Potpie",
-    body: "Successfully logged in. You may return to your CLI.",
+    title: "You're all set",
+    body: "Successfully signed in to Potpie CLI. You can close this window and return to your terminal.",
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds frontend support for Potpie CLI login via `cli_callback` sign-in handoff.
- Exchanges the signed-in Firebase browser session for a backend-minted custom token and posts it back to the local CLI callback listener.
- Adds CLI success page and callback helper tests for the browser-to-CLI login flow.
<img width="1155" height="691" alt="Screenshot 2026-06-03 at 4 34 10 PM" src="https://github.com/user-attachments/assets/eb3aab90-782b-4a7a-ae56-bc9626b48176" />


## Connection To `potpie`
This PR depends on the companion `potpie` PR that starts the local CLI callback server, generates the callback URL/state, exchanges Firebase custom tokens for refresh sessions, and stores credentials locally. The frontend handoff is only useful with that CLI/backend support.

## Test Plan
- Run `pnpm test -- lib/auth/cli-callback.test.ts lib/auth/cli-success.test.ts`.
- Run the companion `potpie` CLI branch and complete `potpie login` through the UI.
- Verify invalid or missing CLI callback state does not complete login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI authentication flow: complete sign-in via a local CLI callback with dedicated success screen and provider-specific messaging.
  * Sign-in UI now shows CLI-specific status, preserves CLI callback through onboarding, and short-circuits normal redirect flows during CLI completion.

* **Tests**
  * Added tests for CLI authentication flows, callback URL validation, success messaging, and concurrency/deduplication behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/potpie-ai/potpie-ui/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->