### PR TITLE
fix(auth): close open redirect & token leak in sign-in redirect params

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/auth/cli-callback";
 import { cliSuccessPath } from "@/lib/auth/cli-success";
 import { buildVSCodeCallbackUrl } from "@/lib/auth/vscode-callback";
+import { getSafeInternalPath } from "@/lib/auth/safe-redirect";
 import { toast } from "@/components/ui/sonner";
 
 export default function AuthLayout({
@@ -101,13 +102,13 @@ export default function AuthLayout({
         !window.location.pathname.startsWith("/link-github") &&
         !window.location.pathname.startsWith("/cli-success")
       ) {
+        // Only ever follow same-origin internal paths — never an attacker-
+        // supplied absolute URL (open redirect, potpie-ai/potpie#596).
+        const safePath = getSafeInternalPath(redirectUrl, "/");
         if (process.env.NODE_ENV === "development") {
-          console.log(
-            "redirecting to",
-            redirectUrl ? decodeURIComponent(redirectUrl) : "/",
-          );
+          console.log("redirecting to", safePath);
         }
-        router.push(redirectUrl ? decodeURIComponent(redirectUrl) : "/");
+        router.push(safePath);
       }
     }
   }, [user, source, redirectUrl, redirect_uri, agent_id, cliCallback, router]);

--- a/lib/auth/safe-redirect.test.ts
+++ b/lib/auth/safe-redirect.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { getSafeInternalPath, isLoopbackCallbackUrl } from "./safe-redirect";
+
+describe("getSafeInternalPath", () => {
+  it("allows same-origin relative paths and preserves query + hash", () => {
+    expect(getSafeInternalPath("/newchat")).toBe("/newchat");
+    expect(getSafeInternalPath("/newchat?repo=x&branch=y")).toBe(
+      "/newchat?repo=x&branch=y",
+    );
+    expect(getSafeInternalPath("/pots/123#section")).toBe("/pots/123#section");
+  });
+
+  it("decodes a URL-encoded internal path", () => {
+    expect(getSafeInternalPath("%2Fnewchat%3Frepo%3Dx")).toBe("/newchat?repo=x");
+  });
+
+  it("rejects absolute external URLs", () => {
+    expect(getSafeInternalPath("https://evil.com")).toBe("/");
+    expect(getSafeInternalPath("http://evil.com/path")).toBe("/");
+    expect(getSafeInternalPath("https%3A%2F%2Fevil.com")).toBe("/");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(getSafeInternalPath("//evil.com")).toBe("/");
+    expect(getSafeInternalPath("/%2Fevil.com")).toBe("/");
+    expect(getSafeInternalPath("%2F%2Fevil.com")).toBe("/");
+  });
+
+  it("rejects backslash and control-character tricks", () => {
+    expect(getSafeInternalPath("/\\evil.com")).toBe("/");
+    expect(getSafeInternalPath("/\\/evil.com")).toBe("/");
+    expect(getSafeInternalPath("\thttps://evil.com")).toBe("/");
+    expect(getSafeInternalPath("/foo\nhttps://evil.com")).toBe("/");
+  });
+
+  it("rejects non-path schemes", () => {
+    expect(getSafeInternalPath("javascript:alert(1)")).toBe("/");
+    expect(getSafeInternalPath("mailto:a@b.com")).toBe("/");
+  });
+
+  it("falls back for empty / nullish input and honours a custom fallback", () => {
+    expect(getSafeInternalPath(null)).toBe("/");
+    expect(getSafeInternalPath(undefined)).toBe("/");
+    expect(getSafeInternalPath("")).toBe("/");
+    expect(getSafeInternalPath("https://evil.com", "/newchat")).toBe("/newchat");
+  });
+});
+
+describe("isLoopbackCallbackUrl", () => {
+  it("accepts loopback http(s) callbacks", () => {
+    expect(isLoopbackCallbackUrl("http://localhost:54333/auth/callback")).toBe(true);
+    expect(isLoopbackCallbackUrl("http://127.0.0.1:0/auth/callback")).toBe(true);
+    expect(isLoopbackCallbackUrl("https://localhost:8080/cb")).toBe(true);
+    expect(isLoopbackCallbackUrl("http://[::1]:5000/auth/callback")).toBe(true);
+  });
+
+  it("rejects non-loopback and non-http targets", () => {
+    expect(isLoopbackCallbackUrl("https://evil.com/auth/callback")).toBe(false);
+    expect(isLoopbackCallbackUrl("http://localhost.evil.com/cb")).toBe(false);
+    expect(isLoopbackCallbackUrl("file:///etc/passwd")).toBe(false);
+    expect(isLoopbackCallbackUrl("/auth/callback")).toBe(false);
+    expect(isLoopbackCallbackUrl(null)).toBe(false);
+    expect(isLoopbackCallbackUrl("")).toBe(false);
+  });
+});

--- a/lib/auth/safe-redirect.ts
+++ b/lib/auth/safe-redirect.ts
@@ -1,0 +1,79 @@
+/**
+ * Helpers for safely handling user-supplied redirect targets in the auth flow.
+ *
+ * Open-redirect protection (issue potpie-ai/potpie#596): the `redirect` query
+ * param on /sign-in (and other auth pages) must only ever send the user to an
+ * internal, same-origin path — never to an attacker-controlled absolute URL.
+ */
+
+// Decode once, defensively. A malformed sequence falls back to the raw value.
+function decodeOnce(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Normalises a user-supplied `redirect` value into a guaranteed-internal path.
+ *
+ * Accepts only same-origin relative paths (e.g. `/newchat?repo=x#y`). Anything
+ * that could navigate off-site — absolute URLs, protocol-relative `//host`,
+ * backslash tricks, control characters, non-`/` values — collapses to `fallback`.
+ */
+export function getSafeInternalPath(
+  raw: string | null | undefined,
+  fallback = "/",
+): string {
+  if (!raw) return fallback;
+
+  const value = decodeOnce(raw).trim();
+
+  // Must be a rooted path, not a scheme (`https:`), and not protocol-relative.
+  if (!value.startsWith("/")) return fallback;
+  if (value.startsWith("//")) return fallback;
+  // Browsers treat backslashes as forward slashes, so `/\evil.com` ==> `//evil.com`.
+  if (value.includes("\\")) return fallback;
+  // Control characters can smuggle a scheme past naive checks.
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return fallback;
+  }
+
+  // Final guard: resolve against a sentinel origin and confirm it stays there.
+  try {
+    const sentinel = "https://internal.invalid";
+    const url = new URL(value, sentinel);
+    if (url.origin !== sentinel) return fallback;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * True only for loopback (localhost) http(s) callback URLs.
+ *
+ * The VS Code extension auth flow legitimately passes a `redirect_uri` pointing
+ * at a local callback server (e.g. `http://localhost:54333/auth/callback`). Any
+ * non-loopback target must be rejected, otherwise the Firebase token appended to
+ * that URL would be exfiltrated to an attacker's domain.
+ */
+export function isLoopbackCallbackUrl(raw: string | null | undefined): boolean {
+  if (!raw) return false;
+
+  try {
+    const url = new URL(decodeOnce(raw).trim());
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    const host = url.hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "[::1]"
+    );
+  } catch {
+    return false;
+  }
+}

--- a/lib/auth/vscode-callback.test.ts
+++ b/lib/auth/vscode-callback.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildVSCodeCallbackUrl } from "./vscode-callback";
+
+const DEFAULT_BASE = "http://localhost:54333/auth/callback";
+
+describe("buildVSCodeCallbackUrl", () => {
+  it("uses the default loopback base when no redirect_uri is given", () => {
+    const url = buildVSCodeCallbackUrl("tok");
+    expect(url.startsWith(`${DEFAULT_BASE}?`)).toBe(true);
+    expect(url).toContain("token=tok");
+  });
+
+  it("honours a loopback redirect_uri (e.g. dynamic VS Code port)", () => {
+    const url = buildVSCodeCallbackUrl("tok", null, "http://127.0.0.1:5123/auth/callback");
+    expect(url.startsWith("http://127.0.0.1:5123/auth/callback?")).toBe(true);
+  });
+
+  it("ignores a non-loopback redirect_uri and keeps the token on the default base", () => {
+    const url = buildVSCodeCallbackUrl("secret-token", "custom", "https://evil.com/steal");
+    expect(url.startsWith(`${DEFAULT_BASE}?`)).toBe(true);
+    expect(url).not.toContain("evil.com");
+    expect(url).toContain("token=secret-token");
+    expect(url).toContain("customToken=custom");
+  });
+
+  it("ignores an encoded non-loopback redirect_uri", () => {
+    const url = buildVSCodeCallbackUrl("tok", null, "https%3A%2F%2Fevil.com%2Fsteal");
+    expect(url.startsWith(`${DEFAULT_BASE}?`)).toBe(true);
+    expect(url).not.toContain("evil.com");
+  });
+});

--- a/lib/auth/vscode-callback.ts
+++ b/lib/auth/vscode-callback.ts
@@ -13,6 +13,8 @@
  * Very long URLs (>2KB) may be truncated by some servers; ensure the callback
  * server allows long query strings if both JWTs are needed.
  */
+import { isLoopbackCallbackUrl } from "@/lib/auth/safe-redirect";
+
 const VSCODE_CALLBACK_BASE_DEFAULT = "http://localhost:54333/auth/callback";
 
 export function buildVSCodeCallbackUrl(
@@ -21,7 +23,10 @@ export function buildVSCodeCallbackUrl(
   redirectUri?: string | null,
 ): string {
   let base = VSCODE_CALLBACK_BASE_DEFAULT;
-  if (redirectUri && redirectUri.trim() !== "") {
+  // The auth token is appended to `base`, so only honour a caller-supplied
+  // redirect_uri when it targets a loopback callback. A non-loopback value
+  // would exfiltrate the token to an attacker (potpie-ai/potpie#596).
+  if (redirectUri && redirectUri.trim() !== "" && isLoopbackCallbackUrl(redirectUri)) {
     try {
       base = decodeURIComponent(redirectUri).replace(/\?.*$/, "");
     } catch {


### PR DESCRIPTION
Fixes the open-redirection vulnerability reported in potpie-ai/potpie#596.

## Problem
The auth pages trusted attacker-controllable redirect parameters and acted on them after authentication:

1. **Open redirect** — `app/(auth)/layout.tsx` ran `router.push(decodeURIComponent(redirect))` on the raw `?redirect=` value, so `https://app.potpie.ai/sign-in?redirect=https://evil.com` navigated the authenticated user to an arbitrary external site.
2. **Token exfiltration (more severe)** — `lib/auth/vscode-callback.ts` used the `?redirect_uri=` value as the callback base and appended the Firebase **token + customToken** to it. A non-loopback `redirect_uri` (e.g. `?source=vscode&redirect_uri=https://evil.com`) would send the user's auth token to an attacker-controlled host.

## Fix
New shared validator `lib/auth/safe-redirect.ts`:
- **`getSafeInternalPath(raw, fallback)`** — accepts only same-origin relative paths. Absolute URLs, protocol-relative `//host`, backslash tricks, control characters and non-`/` values collapse to the fallback (`/`).
- **`isLoopbackCallbackUrl(raw)`** — true only for `http(s)` loopback callbacks (`localhost` / `127.0.0.1` / `::1`).

Wired in:
- `app/(auth)/layout.tsx` redirects via `getSafeInternalPath(redirectUrl, "/")`.
- `lib/auth/vscode-callback.ts` only honours `redirect_uri` when it is a loopback callback, otherwise keeps the default localhost base (token is never sent off-host).

## Tests
13 vitest tests (`lib/auth/safe-redirect.test.ts`, `lib/auth/vscode-callback.test.ts`) covering external/encoded/protocol-relative/backslash/control-char/`javascript:` rejection, internal-path preservation, loopback acceptance, and the VS Code token-leak case. Verified passing locally; `tsc --noEmit` clean on all changed files.

> Note: `main` does not yet carry the vitest config (it lives on `staging`), so these co-located `*.test.ts` files follow the same convention as the existing `lib/auth/cli-callback.test.ts` and will run once that harness lands on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication redirect security by validating that redirects target same-origin internal paths only, preventing open-redirect attacks.
  * Restricted callback URLs to loopback addresses, preventing potential credential exfiltration during authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->