### PR TITLE
fix : replace nested button elements with div in  Sidebar

### DIFF
--- a/components/Layouts/Sidebar.tsx
+++ b/components/Layouts/Sidebar.tsx
@@ -281,7 +281,7 @@ export function AppSidebar() {
                       tooltip={link.title}
                     >
                       {link.showProModal || isWorkflowsLink ? (
-                        <button
+                        <div
                           className="flex gap-2 items-center w-full overflow-hidden"
                           onClick={handleClick}
                         >
@@ -292,7 +292,7 @@ export function AppSidebar() {
                               {link.description}
                             </span>
                           )}
-                        </button>
+                        </div>
                       ) : (
                         <Link
                           href={link.href}


### PR DESCRIPTION
Fixes invalid nested button elements rendered by sidebar menu items.

### Result
- Removes React hydration warnings
- Prevents `<button>` inside `<button>` DOM nesting errors

Fixes #427 