### PR TITLE
fix: restore mobile sidebar accessibility

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -10,7 +10,7 @@ import { AppSidebar } from "@/components/Layouts/Sidebar";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "@/lib/state/store";
 import { setBranchName, setRepoName } from "@/lib/state/Reducers/RepoAndBranch";
-
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 
@@ -54,6 +54,7 @@ export default function RootLayout({
 
 
 function MainContent({ children }: { children: React.ReactNode }) {
+
   return (
     <main
       className={cn(
@@ -61,7 +62,11 @@ function MainContent({ children }: { children: React.ReactNode }) {
         `${GeistSans.variable} ${GeistMono.variable}`
       )}
     >
+      <div className="md:hidden p-2">
+        <SidebarTrigger />
+      </div>
       {children}
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary

This PR restores access to the mobile sidebar by rendering `SidebarTrigger` from the shared application layout.

## Problem

On viewports below 768px, the sidebar is rendered as a `Sheet`, but no visible trigger is available to open it, making navigation inaccessible.

## Solution

* Render `SidebarTrigger` in `app/(main)/layout.tsx`
* Show it only on mobile using `md:hidden`
* Preserve existing desktop behavior

## Testing

Verified on:

* New Chat
* Chat
* Integrations
* Workflows

Fixes #431 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile-only sidebar toggle in the main app layout, making navigation easier on smaller screens.
* **Bug Fixes**
  * Improved the main content layout so the sidebar control appears in the appropriate mobile view without affecting desktop display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->