### PR TITLE
Fix spec guardrail TypeScript build error

### DIFF
--- a/app/(main)/task/[taskId]/spec/page.tsx
+++ b/app/(main)/task/[taskId]/spec/page.tsx
@@ -120,7 +120,7 @@ function normalizePlanItem(item: any, idx: number, prefix: string): PlanItem {
     .filter((depId: string) => depId && String(depId).trim() !== "" && String(depId) !== String(id));
   const externalConnections = rawConns.map((c: any) => typeof c === "string" ? c : (c && typeof c === "object" && "name" in c ? String(c.name) : String(c)));
   const guardrails = rawGuardrails
-    .map((g: any) => {
+    .map((g: any): GuardrailItem | null => {
       if (typeof g === "string") {
         return { statement: g };
       }
@@ -133,7 +133,7 @@ function normalizePlanItem(item: any, idx: number, prefix: string): PlanItem {
         consequences: Array.isArray(g?.consequences) ? g.consequences.map((c: any) => String(c)) : undefined,
       };
     })
-    .filter((guardrail): guardrail is GuardrailItem => guardrail !== null);
+    .filter((guardrail: GuardrailItem | null): guardrail is GuardrailItem => guardrail !== null);
   const acceptanceCriteria = rawAcceptanceCriteria.map((c: any) => typeof c === "string" ? c : (c?.text ?? JSON.stringify(c)));
   const context = item?.context ?? "";
   return {
@@ -185,7 +185,7 @@ function specOutputToPlan(raw: SpecificationOutput): Plan {
       const extStrings = rawExt.map((e: any) => typeof e === "string" ? e : (e?.name != null ? String(e.name) : String(e)));
       const rawGuardrails = Array.isArray(item?.guardrails) ? item.guardrails : [];
       const guardrails = rawGuardrails
-        .map((g: any) => {
+        .map((g: any): GuardrailItem | null => {
           if (typeof g === "string") {
             return { statement: g };
           }
@@ -198,7 +198,7 @@ function specOutputToPlan(raw: SpecificationOutput): Plan {
             consequences: Array.isArray(g?.consequences) ? g.consequences.map((c: any) => String(c)) : undefined,
           };
         })
-        .filter((guardrail): guardrail is GuardrailItem => guardrail !== null);
+        .filter((guardrail: GuardrailItem | null): guardrail is GuardrailItem => guardrail !== null);
       const acceptanceCriteria = Array.isArray(item?.acceptance_criteria)
         ? item.acceptance_criteria.map((c: any) => typeof c === "string" ? c : (c?.text ?? JSON.stringify(c)))
         : [];


### PR DESCRIPTION
## Summary
- Adds explicit `GuardrailItem | null` typing to spec guardrail normalization.
- Fixes the implicit `any` TypeScript error in the spec page build.
- Keeps UI behavior unchanged.

## Verification
- `pnpm lint`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type handling for task spec guardrail processing.
  * No user-facing behavior or output changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->