### PR TITLE
fix: remediate websocket-driver critical vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
       "dompurify": "^3.4.11",
       "lodash-es": "^4.18.1",
       "@grpc/grpc-js": "1.9.16",
-      "@opentelemetry/core": "2.8.0"
+      "@opentelemetry/core": "2.8.0",
+      "websocket-driver": "0.7.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   lodash-es: ^4.18.1
   '@grpc/grpc-js': 1.9.16
   '@opentelemetry/core': 2.8.0
+  websocket-driver: 0.7.5
 
 importers:
 
@@ -5192,8 +5193,8 @@ packages:
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -8669,7 +8670,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -10972,7 +10973,7 @@ snapshots:
 
   web-vitals@5.1.0: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pin transitive `websocket-driver` to patched version 0.7.5
- update the pnpm lockfile to remove vulnerable version 0.7.4
- remediate CVE-2026-54466

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm why websocket-driver` (single resolved version: 0.7.5)
- `pnpm audit --prod --audit-level critical` (no known vulnerabilities)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-1966](https://linear.app/potpie/issue/POT-1966/vanta-potpie-aipotpie-ui-critical-vulnerabilities-1)

<div><a href="https://cursor.com/agents/bc-bdb54d2e-7e26-40ad-a42a-31ee0ad66682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdb54d2e-7e26-40ad-a42a-31ee0ad66682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal package version override to improve dependency consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->