### PR TITLE
fix(deps): remediate CVE-2026-53550 in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
       "undici": "^6.21.2",
       "@isaacs/brace-expansion": "^5.0.1",
       "brace-expansion": "^2.0.2",
-      "js-yaml": "^4.1.1",
+      "js-yaml": "^4.2.0",
       "prismjs": "^1.30.0",
       "dompurify": "^3.4.11",
       "lodash-es": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   undici: ^6.21.2
   '@isaacs/brace-expansion': ^5.0.1
   brace-expansion: ^2.0.2
-  js-yaml: ^4.1.1
+  js-yaml: ^4.2.0
   prismjs: ^1.30.0
   dompurify: ^3.4.11
   lodash-es: ^4.18.1
@@ -3810,8 +3810,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5639,7 +5639,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8584,7 +8584,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -9165,7 +9165,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- raise the `js-yaml` override above the vulnerable `<=4.1.1` range
- refresh the lockfile to resolve `js-yaml` 4.3.0
- remediate CVE-2026-53550

## Testing
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm why js-yaml` (one resolved version: 4.3.0)
- `pnpm audit --json` (`js-yaml` finding: none)

Review requested from @yashkrishan.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-1660](https://linear.app/potpie/issue/POT-1660/vanta-potpie-aipotpie-ui-medium-vulnerabilities-1)

<div><a href="https://cursor.com/agents/bc-82ecdeff-5e4a-471c-8859-2f7c8e833d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ecdeff-5e4a-471c-8859-2f7c8e833d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying YAML processing component to a newer compatible release.
  * This maintenance update keeps the application’s supporting software current and may improve compatibility and reliability.
  * No user-facing features, workflows, or visual changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->