### PR TITLE
fix: remediate Axios and protobufjs vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "pnpm": {
     "overrides": {
-      "protobufjs": "7.6.4",
+      "protobufjs": "7.6.5",
       "@protobufjs/utf8": "1.1.1",
       "follow-redirects": "1.16.0",
       "postcss": "8.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  protobufjs: 7.6.4
+  protobufjs: 7.6.5
   '@protobufjs/utf8': 1.1.1
   follow-redirects: 1.16.0
   postcss: 8.5.10
@@ -4464,8 +4464,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -5995,7 +5995,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@hookform/resolvers@3.10.0(react-hook-form@7.71.1(react@18.3.1))':
@@ -6320,7 +6320,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -10038,7 +10038,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- retain the `axios` 1.18.1 remediation already present on `main`
- upgrade the transitive `protobufjs` override from 7.6.4 to 7.6.5, outside the affected CVE-2026-59877 range
- refresh only the corresponding lockfile resolutions

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`

Review requested from @yashkrishan.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-1996](https://linear.app/potpie/issue/POT-1996/vanta-potpie-aipotpie-ui-medium-vulnerabilities-4)

<div><a href="https://cursor.com/agents/bc-bc232b97-65ec-4cd4-be52-353b6c13e8a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc232b97-65ec-4cd4-be52-353b6c13e8a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `protobufjs` version to 7.6.5 for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->