### PR TITLE
fix: remediate Next.js high-severity vulnerabilities (POT-2027)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "mermaid": "^11.15.0",
     "minimatch": "^10.2.5",
     "motion": "^12.5.0",
-    "next": "^15.5.21",
+    "next": "15.5.21",
     "next-themes": "^0.3.0",
     "posthog-js": "^1.231.0",
     "prism-react-renderer": "^2.4.1",
@@ -135,7 +135,8 @@
       "lodash-es": "^4.18.1",
       "@grpc/grpc-js": "1.9.16",
       "@opentelemetry/core": "2.8.0",
-      "websocket-driver": "0.7.5"
+      "websocket-driver": "0.7.5",
+      "next": "15.5.21"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   '@grpc/grpc-js': 1.9.16
   '@opentelemetry/core': 2.8.0
   websocket-driver: 0.7.5
+  next: 15.5.21
 
 importers:
 
@@ -194,7 +195,7 @@ importers:
         specifier: ^12.5.0
         version: 12.29.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next:
-        specifier: ^15.5.21
+        specifier: 15.5.21
         version: 15.5.21(@opentelemetry/api@1.9.0)(@types/node@20.19.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
@@ -3367,7 +3368,7 @@ packages:
   geist@1.5.1:
     resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
     peerDependencies:
-      next: '>=13.2.0'
+      next: 15.5.21
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Pin `next` to `15.5.21` (exact) and add a `pnpm.overrides` entry so the patched release cannot be pulled below the fixed range
- Remediates Dependabot/Vanta high findings:
  - CVE-2026-64641
  - CVE-2026-64645
  - CVE-2026-64649
- Builds on the Next.js upgrade already merged in #442 (`15.5.18` → `15.5.21`); this PR locks the patched version for the high-severity Vanta test

## Testing
- `pnpm install`
- Confirmed only `next@15.5.21` is resolved (`pnpm why next`)
- `pnpm run lint` — passes (pre-existing warnings only)
- `pnpm run build` — succeeds on Next.js 15.5.21

## Review
@yashkrishan please review (API review-request was not permitted for this token).

Linear issue: [POT-2027](https://linear.app/potpie/issue/POT-2027/vanta-potpie-aipotpie-ui-high-vulnerabilities-3)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2027](https://linear.app/potpie/issue/POT-2027/vanta-potpie-aipotpie-ui-high-vulnerabilities-3)

<div><a href="https://cursor.com/agents/bc-9a3ebacc-d79d-40b9-8ea3-3cf5c6689b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a3ebacc-d79d-40b9-8ea3-3cf5c6689b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Next.js framework version to 15.5.21 for more consistent application builds.
  * Added an override to ensure the specified Next.js version is used throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->