### PR TITLE
fix: remediate brace-expansion and postcss high vulnerabilities [POT-2049]

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
       "mdast-util-to-hast": "13.2.1",
       "undici": "^6.21.2",
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": "2.1.2",
+      "brace-expansion": "5.0.8",
       "sharp": "0.35.3",
       "js-yaml": "^4.2.0",
       "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   mdast-util-to-hast: 13.2.1
   undici: ^6.21.2
   '@isaacs/brace-expansion': ^5.0.1
-  brace-expansion: 2.1.2
+  brace-expansion: 5.0.8
   sharp: 0.35.3
   js-yaml: ^4.2.0
   prismjs: ^1.30.0
@@ -2551,8 +2551,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.9.17:
     resolution: {integrity: sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==}
@@ -2562,8 +2563,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -7661,15 +7663,15 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.17: {}
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@2.1.2:
+  brace-expansion@5.0.8:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -9559,15 +9561,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Upgrade `brace-expansion` override from `2.1.2` → `5.0.8` to remediate **CVE-2026-14257** (Dependabot/Vanta range `<=5.0.7`)
- Confirm `postcss` remains pinned at `8.5.23` (`>=8.5.18`) for GHSA-r28c-9q8g-f849 / Dependabot alert covering `postcss <= 8.5.17`

## Testing
- `pnpm audit --audit-level=high` — no known vulnerabilities
- `pnpm run lint` — passed (pre-existing warnings only)
- `pnpm run build` — passed

## Linear
- [POT-2049](https://linear.app/potpie/issue/POT-2049/vanta-potpie-aipotpie-ui-high-vulnerabilities-2)

Reviewer: @yashkrishan

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2049](https://linear.app/potpie/issue/POT-2049/vanta-potpie-aipotpie-ui-high-vulnerabilities-2)

<div><a href="https://cursor.com/agents/bc-c1b0f6e6-68fd-4fe7-8476-fa8780a8755b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1b0f6e6-68fd-4fe7-8476-fa8780a8755b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal package override to use a newer version of `brace-expansion`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->