### PR TITLE
fix(security): remediate FW001–FW004 on frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 
 FROM base AS deps
 RUN apk add --no-cache libc6-compat

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install pnpm globally
-RUN npm install -g pnpm
+# Pin pnpm to v9: lockfileVersion 9.0 + package.json pnpm.overrides.
+# Unpinned "pnpm" resolves to v11+, which ignores package.json#pnpm and
+# fails CI with ERR_PNPM_IGNORED_BUILDS for native postinstall scripts.
+RUN npm install -g pnpm@9
+ENV CI=true
 
 # Copy the package.json and pnpm-lock.yaml files
 COPY package.json pnpm-lock.yaml ./
@@ -17,7 +20,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 COPY next.config.mjs ./
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 
 ARG NEXT_PUBLIC_FIREBASE_API_KEY
 ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN

--- a/Dockerfile.Portable
+++ b/Dockerfile.Portable
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 
 FROM base AS deps
 RUN apk add --no-cache libc6-compat

--- a/Dockerfile.Portable
+++ b/Dockerfile.Portable
@@ -4,8 +4,11 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install pnpm globally
-RUN npm install -g pnpm
+# Pin pnpm to v9: lockfileVersion 9.0 + package.json pnpm.overrides.
+# Unpinned "pnpm" resolves to v11+, which ignores package.json#pnpm and
+# fails CI with ERR_PNPM_IGNORED_BUILDS for native postinstall scripts.
+RUN npm install -g pnpm@9
+ENV CI=true
 
 # Copy the package.json and pnpm-lock.yaml files
 COPY package.json pnpm-lock.yaml ./
@@ -17,7 +20,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 COPY next.config.mjs ./
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9
 
 ARG NEXT_PUBLIC_FIREBASE_API_KEY
 ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -495,7 +495,11 @@ const Signup = () => {
                         type={showPassword ? "text" : "password"}
                         placeholder="••••••••••"
                         autoComplete="new-password"
-                        aria-describedby="password-requirements"
+                        aria-describedby={
+                          form.formState.errors.password
+                            ? "password-requirements password-validation-error"
+                            : "password-requirements"
+                        }
                         aria-invalid={Boolean(form.formState.errors.password)}
                         {...form.register("password")}
                         className="w-full bg-transparent text-sm text-[#022D2C] placeholder:text-[#A6AFA9] focus:outline-none"
@@ -510,7 +514,12 @@ const Signup = () => {
                       </button>
                     </div>
                     {form.formState.errors.password && (
-                      <p className="text-sm text-red-600">{form.formState.errors.password.message}</p>
+                      <p
+                        id="password-validation-error"
+                        className="text-sm text-red-600"
+                      >
+                        {form.formState.errors.password.message}
+                      </p>
                     )}
                     <div id="password-requirements" className="space-y-2 pt-1">
                       <div className="flex items-center justify-between text-xs">

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Button } from "@/components/ui/button";
-import { Eye, EyeOff } from "lucide-react";
+import { CheckCircle2, Circle, Eye, EyeOff } from "lucide-react";
 import Image from "next/image";
 import React from "react";
 import Link from "next/link";
@@ -20,10 +20,11 @@ import AuthService from "@/services/AuthService";
 import axios from "axios";
 import posthog from "posthog-js";
 import { authClient } from '@/lib/sso/unified-auth';
+import { evaluatePassword, passwordSchema } from "@/lib/auth/password-policy";
 
 const formSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
-  password: z.string().min(6, { message: "Password must be at least 6 characters" }),
+  password: passwordSchema,
 });
 
 const Signup = () => {
@@ -149,6 +150,25 @@ const Signup = () => {
       password: "",
     },
   });
+  const password = form.watch("password");
+  const passwordEvaluation = evaluatePassword(password);
+  const passwordStrengthPercentage = password
+    ? (passwordEvaluation.metRequirementCount /
+        passwordEvaluation.requirements.length) *
+      100
+    : 0;
+  const passwordStrengthColor =
+    passwordEvaluation.strength === "Strong"
+      ? "bg-[#24713B]"
+      : passwordEvaluation.strength === "Fair"
+        ? "bg-[#D97706]"
+        : "bg-[#DC2626]";
+  const passwordStrengthTextColor =
+    passwordEvaluation.strength === "Strong"
+      ? "text-[#24713B]"
+      : passwordEvaluation.strength === "Fair"
+        ? "text-[#A85D00]"
+        : "text-[#B91C1C]";
 
   const handleSSONeedsLinking = (response: SSOLoginResponse) => {
     setLinkingData(response);
@@ -474,6 +494,9 @@ const Signup = () => {
                       <input
                         type={showPassword ? "text" : "password"}
                         placeholder="••••••••••"
+                        autoComplete="new-password"
+                        aria-describedby="password-requirements"
+                        aria-invalid={Boolean(form.formState.errors.password)}
                         {...form.register("password")}
                         className="w-full bg-transparent text-sm text-[#022D2C] placeholder:text-[#A6AFA9] focus:outline-none"
                       />
@@ -489,6 +512,47 @@ const Signup = () => {
                     {form.formState.errors.password && (
                       <p className="text-sm text-red-600">{form.formState.errors.password.message}</p>
                     )}
+                    <div id="password-requirements" className="space-y-2 pt-1">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-[#656969]">Password strength</span>
+                        <span
+                          className={password ? passwordStrengthTextColor : "text-[#8A8E8B]"}
+                          aria-live="polite"
+                        >
+                          {password ? passwordEvaluation.strength : "Not entered"}
+                        </span>
+                      </div>
+                      <div
+                        role="progressbar"
+                        aria-label="Password strength"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={passwordStrengthPercentage}
+                        className="h-1.5 w-full overflow-hidden rounded-full bg-[#E5E7E6]"
+                      >
+                        <div
+                          className={`h-full rounded-full transition-[width] duration-200 ${passwordStrengthColor}`}
+                          style={{ width: `${passwordStrengthPercentage}%` }}
+                        />
+                      </div>
+                      <ul className="grid grid-cols-2 gap-x-3 gap-y-1">
+                        {passwordEvaluation.requirements.map((requirement) => (
+                          <li
+                            key={requirement.id}
+                            className={`flex items-center gap-1.5 text-xs ${
+                              requirement.isMet ? "text-[#24713B]" : "text-[#656969]"
+                            }`}
+                          >
+                            {requirement.isMet ? (
+                              <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                            ) : (
+                              <Circle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                            )}
+                            <span>{requirement.label}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
                   </div>
 
                   <p className="mt-4 text-xs text-[#656969] text-center">

--- a/lib/auth/password-policy.test.mjs
+++ b/lib/auth/password-policy.test.mjs
@@ -1,3 +1,7 @@
+/**
+ * Run via: pnpm test:unit
+ * (Node >=22; uses --experimental-strip-types for .ts imports)
+ */
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 

--- a/lib/auth/password-policy.test.mjs
+++ b/lib/auth/password-policy.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { evaluatePassword, passwordSchema } from "./password-policy.ts";
+import { getUserFriendlyError } from "../utils/errorMessages.ts";
+
+describe("password policy", () => {
+  it("accepts a password that satisfies every requirement", () => {
+    assert.equal(passwordSchema.safeParse("ValidPassword1!").success, true);
+  });
+
+  it("rejects a password shorter than 15 characters", () => {
+    assert.equal(passwordSchema.safeParse("StrongPass123!").success, false);
+    assert.equal(passwordSchema.safeParse("Abcdefghijk1!😀").success, false);
+  });
+
+  it("rejects each missing character class", () => {
+    const invalidPasswords = [
+      "securepassphrase1!",
+      "SECUREPASSPHRASE1!",
+      "SecurePassphrase!!",
+      "SecurePassphrase12",
+    ];
+
+    for (const password of invalidPasswords) {
+      assert.equal(passwordSchema.safeParse(password).success, false);
+    }
+  });
+
+  it("matches Firebase's supported non-alphanumeric characters", () => {
+    assert.equal(passwordSchema.safeParse("SecurePassphrase1-").success, false);
+    assert.equal(passwordSchema.safeParse("SecurePassphrase1_").success, true);
+  });
+
+  it("reports requirement progress for real-time feedback", () => {
+    const weak = evaluatePassword("password");
+    const strong = evaluatePassword("ValidPassword1!");
+
+    assert.equal(weak.metRequirementCount, 1);
+    assert.equal(weak.strength, "Weak");
+    assert.equal(strong.metRequirementCount, 5);
+    assert.equal(strong.strength, "Strong");
+    assert.equal(strong.isValid, true);
+  });
+
+  it("explains the active policy when Firebase rejects a weak password", () => {
+    assert.equal(
+      getUserFriendlyError({ code: "auth/weak-password" }),
+      "Use 15 or more characters with uppercase, lowercase, a number, and a special character.",
+    );
+  });
+});

--- a/lib/auth/password-policy.ts
+++ b/lib/auth/password-policy.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+
+export type PasswordStrength = "Weak" | "Fair" | "Strong";
+
+export type PasswordRequirementId =
+  | "length"
+  | "uppercase"
+  | "lowercase"
+  | "number"
+  | "special";
+
+export interface PasswordRequirementResult {
+  id: PasswordRequirementId;
+  label: string;
+  isMet: boolean;
+}
+
+export interface PasswordEvaluation {
+  isValid: boolean;
+  metRequirementCount: number;
+  requirements: PasswordRequirementResult[];
+  strength: PasswordStrength;
+}
+
+export const PASSWORD_POLICY_ERROR =
+  "Use 15 or more characters with uppercase, lowercase, a number, and a special character.";
+
+const FIREBASE_SPECIAL_CHARACTERS = new Set([
+  "^",
+  "$",
+  "*",
+  ".",
+  "[",
+  "]",
+  "{",
+  "}",
+  "(",
+  ")",
+  "?",
+  '"',
+  "!",
+  "@",
+  "#",
+  "%",
+  "&",
+  "/",
+  "\\",
+  ",",
+  ">",
+  "<",
+  "'",
+  ":",
+  ";",
+  "|",
+  "_",
+  "~",
+]);
+
+export function evaluatePassword(password: string): PasswordEvaluation {
+  const characters = Array.from(password);
+  const requirements: PasswordRequirementResult[] = [
+    {
+      id: "length",
+      label: "15+ characters",
+      isMet: characters.length >= 15,
+    },
+    {
+      id: "uppercase",
+      label: "Uppercase letter",
+      isMet: /[A-Z]/.test(password),
+    },
+    {
+      id: "lowercase",
+      label: "Lowercase letter",
+      isMet: /[a-z]/.test(password),
+    },
+    {
+      id: "number",
+      label: "Number",
+      isMet: /[0-9]/.test(password),
+    },
+    {
+      id: "special",
+      label: "Special character",
+      isMet: characters.some((character) =>
+        FIREBASE_SPECIAL_CHARACTERS.has(character),
+      ),
+    },
+  ];
+  const metRequirementCount = requirements.filter(
+    (requirement) => requirement.isMet,
+  ).length;
+  const strength: PasswordStrength =
+    metRequirementCount === requirements.length
+      ? "Strong"
+      : metRequirementCount >= 3
+        ? "Fair"
+        : "Weak";
+
+  return {
+    isValid: metRequirementCount === requirements.length,
+    metRequirementCount,
+    requirements,
+    strength,
+  };
+}
+
+export const passwordSchema = z.string().superRefine((password, context) => {
+  if (!evaluatePassword(password).isValid) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: PASSWORD_POLICY_ERROR,
+    });
+  }
+});

--- a/lib/utils/errorMessages.ts
+++ b/lib/utils/errorMessages.ts
@@ -66,7 +66,7 @@ function getUserFriendlyMessage(message: string): string {
   }
   
   if (lowerMessage.includes('weak password') || lowerMessage.includes('password is too weak')) {
-    return 'Password is too weak. Please use a stronger password (at least 6 characters).';
+    return 'Use 15 or more characters with uppercase, lowercase, a number, and a special character.';
   }
 
   // SSO/Provider errors
@@ -153,7 +153,7 @@ function getUserFriendlyMessage(message: string): string {
   }
   
   if (lowerMessage.includes('auth/weak-password')) {
-    return 'Password is too weak. Please use a stronger password.';
+    return 'Use 15 or more characters with uppercase, lowercase, a number, and a special character.';
   }
   
   if (lowerMessage.includes('auth/invalid-email')) {
@@ -218,4 +218,3 @@ export function getUserFriendlyProviderName(providerType: string): string {
   
   return providerMap[providerType] || providerType.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
 }
-

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,45 @@
 /** @type {import('next').NextConfig} */
+
+/** Remediation FW002 / CWE-319 — only emit on production builds. */
+export const HSTS_HEADER_VALUE =
+  "max-age=31536000; includeSubDomains; preload";
+
+/** Remediation FW004 / CWE-1021 */
+export const X_FRAME_OPTIONS_VALUE = "DENY";
+export const CSP_FRAME_ANCESTORS = "frame-ancestors 'self'";
+
+/**
+ * @param {{ nodeEnv?: string | undefined }} [options]
+ * @returns {{ source: string, headers: { key: string, value: string }[] }[]}
+ */
+export function securityHeaders({ nodeEnv = process.env.NODE_ENV } = {}) {
+  /** @type {{ key: string, value: string }[]} */
+  const headers = [
+    {
+      key: "X-Frame-Options",
+      value: X_FRAME_OPTIONS_VALUE,
+    },
+    {
+      key: "Content-Security-Policy",
+      value: CSP_FRAME_ANCESTORS,
+    },
+  ];
+
+  if (nodeEnv === "production") {
+    headers.push({
+      key: "Strict-Transport-Security",
+      value: HSTS_HEADER_VALUE,
+    });
+  }
+
+  return [
+    {
+      source: "/:path*",
+      headers,
+    },
+  ];
+}
+
 const nextConfig = {
   images: {
     domains: ["avatars.githubusercontent.com"],
@@ -15,6 +56,9 @@ const nextConfig = {
     ignoreBuildErrors: false,
   },
   reactStrictMode: true,
+  async headers() {
+    return securityHeaders();
+  },
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,9 +4,9 @@
 export const HSTS_HEADER_VALUE =
   "max-age=31536000; includeSubDomains; preload";
 
-/** Remediation FW004 / CWE-1021 */
+/** Remediation FW004 / CWE-1021 — DENY ≡ CSP frame-ancestors 'none'. */
 export const X_FRAME_OPTIONS_VALUE = "DENY";
-export const CSP_FRAME_ANCESTORS = "frame-ancestors 'self'";
+export const CSP_FRAME_ANCESTORS = "frame-ancestors 'none'";
 
 /**
  * @param {{ nodeEnv?: string | undefined }} [options]

--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
   "name": "potpie",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:unit": "node --test tests/*.test.mjs && node --experimental-strip-types --test lib/auth/password-policy.test.mjs"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.2.5",

--- a/services/AgentService.ts
+++ b/services/AgentService.ts
@@ -3,6 +3,9 @@ import getHeaders from "@/app/utils/headers.util";
 import { CustomAgentsFormValues } from "@/lib/Schema";
 import { parseApiError } from "@/lib/utils";
 
+/** Server-defined list scopes (FW003). Client privilege flags are not used. */
+export type AgentListMode = "runtime" | "owned";
+
 export default class AgentService {
   static async getAgentTypes() {
     const headers = await getHeaders();
@@ -12,6 +15,9 @@ export default class AgentService {
         `${baseUrl}/api/v1/list-available-agents/`,
         {
           headers: headers,
+          params: {
+            mode: "runtime" satisfies AgentListMode,
+          },
         }
       );
       return response.data;
@@ -21,35 +27,21 @@ export default class AgentService {
     }
   }
 
-  static async getAgentList(includePublic = false, includeShared = false) {
+  static async getAgentList(_includePublic = false, _includeShared = false) {
     const headers = await getHeaders();
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
     try {
-      console.log("Fetching agent list with params:", {
-        includePublic,
-        includeShared,
-      });
+      // Management view: only agents owned by the authenticated user.
+      // Legacy includePublic/includeShared args are ignored (server enforces mode).
       const response: any = await axios.get(
         `${baseUrl}/api/v1/list-available-agents/`,
         {
           params: {
-            list_system_agents: false,
-            include_public: includePublic,
-            include_shared: includeShared,
+            mode: "owned" satisfies AgentListMode,
           },
           headers: headers,
         }
       );
-      console.log("Agent list response:", response.data);
-
-      // Log visibility information for each agent
-      if (response.data && Array.isArray(response.data)) {
-        response.data.forEach((agent: any) => {
-          console.log(
-            `Agent ${agent.id} (${agent.name}) visibility: ${agent.visibility}`
-          );
-        });
-      }
 
       return response.data;
     } catch (error) {

--- a/tests/hstsHeaders.test.mjs
+++ b/tests/hstsHeaders.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CSP_FRAME_ANCESTORS,
+  HSTS_HEADER_VALUE,
+  X_FRAME_OPTIONS_VALUE,
+  securityHeaders,
+} from "../next.config.mjs";
+
+test("production builds emit HSTS and anti-framing headers application-wide", async () => {
+  const headers = await securityHeaders({ nodeEnv: "production" });
+
+  assert.equal(headers.length, 1);
+  assert.equal(headers[0].source, "/:path*");
+  assert.deepEqual(headers[0].headers, [
+    { key: "X-Frame-Options", value: X_FRAME_OPTIONS_VALUE },
+    { key: "Content-Security-Policy", value: CSP_FRAME_ANCESTORS },
+    { key: "Strict-Transport-Security", value: HSTS_HEADER_VALUE },
+  ]);
+  assert.equal(X_FRAME_OPTIONS_VALUE, "DENY");
+  assert.equal(CSP_FRAME_ANCESTORS, "frame-ancestors 'self'");
+  assert.equal(
+    HSTS_HEADER_VALUE,
+    "max-age=31536000; includeSubDomains; preload",
+  );
+});
+
+test("non-production builds still emit anti-framing headers but omit HSTS", async () => {
+  const headers = await securityHeaders({ nodeEnv: "development" });
+
+  assert.equal(headers.length, 1);
+  assert.deepEqual(headers[0].headers, [
+    { key: "X-Frame-Options", value: "DENY" },
+    { key: "Content-Security-Policy", value: "frame-ancestors 'self'" },
+  ]);
+  assert.equal(
+    headers[0].headers.some((h) => h.key === "Strict-Transport-Security"),
+    false,
+  );
+});

--- a/tests/hstsHeaders.test.mjs
+++ b/tests/hstsHeaders.test.mjs
@@ -19,7 +19,7 @@ test("production builds emit HSTS and anti-framing headers application-wide", as
     { key: "Strict-Transport-Security", value: HSTS_HEADER_VALUE },
   ]);
   assert.equal(X_FRAME_OPTIONS_VALUE, "DENY");
-  assert.equal(CSP_FRAME_ANCESTORS, "frame-ancestors 'self'");
+  assert.equal(CSP_FRAME_ANCESTORS, "frame-ancestors 'none'");
   assert.equal(
     HSTS_HEADER_VALUE,
     "max-age=31536000; includeSubDomains; preload",
@@ -32,7 +32,7 @@ test("non-production builds still emit anti-framing headers but omit HSTS", asyn
   assert.equal(headers.length, 1);
   assert.deepEqual(headers[0].headers, [
     { key: "X-Frame-Options", value: "DENY" },
-    { key: "Content-Security-Policy", value: "frame-ancestors 'self'" },
+    { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
   ]);
   assert.equal(
     headers[0].headers.some((h) => h.key === "Strict-Transport-Security"),


### PR DESCRIPTION
## Summary
- **FW001 (CWE-521):** Enforce a central 15+ character password policy (uppercase, lowercase, number, Firebase-supported special characters) on signup, with live strength feedback and a requirements checklist. Updated weak-password user messaging; sign-in validation left unchanged so existing accounts are not locked out.
- **FW002 (CWE-319):** Emit `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` from Next.js in production builds.
- **FW003 (CWE-639):** Stop sending client privilege flags (`list_system_agents` / `include_public` / `include_shared`). Agent listing now uses server-defined `mode=runtime|owned`.
- **FW004 (CWE-1021):** Add anti-framing headers application-wide: `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'self'`.

## Scope
- Password policy module + signup UI + error copy
- `next.config.mjs` security headers + header unit tests
- `AgentService` list/catalog calls use `mode` only

## Out of scope / follow-up
- Firebase Authentication → Password policy must still be set to **Require**, min length **15**, with the same complexity rules, and **force upgrade on sign-in disabled**. Frontend enforcement alone can be bypassed via direct Firebase API calls until that config is applied.
- Breached-password (HIBP) checks and login throttling are intentionally not in this PR (separate controls; not in the report’s stated remediation).
- Unrelated local API error-sanitizer work was not included.

## Test plan
- [ ] `node --test lib/auth/password-policy.test.mjs`
- [ ] `node --test tests/hstsHeaders.test.mjs`
- [ ] Signup rejects passwords under 15 chars or missing any required character class
- [ ] Signup strength meter / checklist updates as the user types
- [ ] Existing users can still sign in with older passwords
- [ ] All Agents uses owned-mode listing; chat agent picker uses runtime mode
- [ ] Production build emits HSTS + anti-framing headers; local/dev still gets anti-framing without HSTS
- [ ] After Firebase policy update: direct weak-password create is rejected by Firebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-up now provides live password-strength feedback, requirement indicators, and clearer validation guidance.
  * Improved password input accessibility and autocomplete support.
  * Enhanced security protections help prevent clickjacking, with stricter transport security in production.

* **Bug Fixes**
  * Agent lists now consistently display the appropriate runtime or user-owned agents.
  * Weak-password messages now clearly describe all required criteria.

* **Tests**
  * Added coverage for password validation, strength evaluation, and security headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->