### PR TITLE
fix(security): bump brace-expansion to 5.0.9 for CVE-2026-69152 (POT-2133)

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
       "mdast-util-to-hast": "13.2.1",
       "undici": "^6.21.2",
       "@isaacs/brace-expansion": "^5.0.1",
-      "brace-expansion": "5.0.8",
+      "brace-expansion": "5.0.9",
       "sharp": "0.35.3",
       "js-yaml": "^4.2.0",
       "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   mdast-util-to-hast: 13.2.1
   undici: ^6.21.2
   '@isaacs/brace-expansion': ^5.0.1
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   sharp: 0.35.3
   js-yaml: ^4.2.0
   prismjs: ^1.30.0
@@ -2563,8 +2563,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -7669,7 +7669,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9561,15 +9561,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Remediates **CVE-2026-69152** (Dependabot alert [#190](https://github.com/potpie-ai/potpie-ui/security/dependabot/190)) reported by Vanta for High severity package vulnerabilities.

`brace-expansion` was pinned at `5.0.8` via `pnpm.overrides` (fix for CVE-2026-14257). That version remains vulnerable to a DoS via unbounded intermediate arrays. Patched version is **5.0.9**.

Linear: [POT-2133](https://linear.app/potpie/issue/POT-2133)

## Changes
- Update `pnpm.overrides["brace-expansion"]` from `5.0.8` → `5.0.9`
- Refresh `pnpm-lock.yaml`

## Verification
- `pnpm why brace-expansion` resolves to `5.0.9`
- `pnpm audit --prod` reports no known vulnerabilities
- Unit tests pass

## Reviewers
Please review: @yashkrishan

Do not mark POT-2133 Done — the Vanta poller closes the issue when the finding clears.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2133](https://linear.app/potpie/issue/POT-2133/vanta-potpie-aipotpie-ui-high-vulnerabilities-1)

<div><a href="https://cursor.com/agents/bc-dbc7b12c-5f80-4b19-b08a-1b709dbdaab9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbc7b12c-5f80-4b19-b08a-1b709dbdaab9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal package override to a newer patch version for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->