### PR TITLE
fix(security): remediate CVE-2026-67214 in nanoid (POT-2232)

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
       "@grpc/grpc-js": "1.9.16",
       "@opentelemetry/core": "2.8.0",
       "websocket-driver": "0.7.5",
-      "next": "15.5.21"
+      "next": "15.5.21",
+      "nanoid@>=4.0.0 <5.1.16": "5.1.16"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   '@opentelemetry/core': 2.8.0
   websocket-driver: 0.7.5
   next: 15.5.21
+  nanoid@>=4.0.0 <5.1.16: 5.1.16
 
 importers:
 
@@ -4107,8 +4108,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -5372,7 +5373,7 @@ snapshots:
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.27)(react@18.3.1)
       assistant-cloud: 0.1.15
       assistant-stream: 0.3.0
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-textarea-autosize: 8.5.9(@types/react@18.3.27)(react@18.3.1)
@@ -7613,13 +7614,13 @@ snapshots:
   assistant-stream@0.2.47:
     dependencies:
       '@standard-schema/spec': 1.1.0
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       secure-json-parse: 4.1.0
 
   assistant-stream@0.3.0:
     dependencies:
       '@standard-schema/spec': 1.1.0
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       secure-json-parse: 4.1.0
 
   ast-types-flow@0.0.8: {}
@@ -9612,7 +9613,7 @@ snapshots:
 
   nanoid@3.3.16: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   napi-postinstall@0.3.4: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remediates **CVE-2026-67214** (High) in `nanoid` (`>=4.0.0 <5.1.16`) tracked by Vanta / Dependabot for `potpie-ai/potpie-ui`.
- Adds a pnpm override `"nanoid@>=4.0.0 <5.1.16": "5.1.16"` so transitive consumers (`@assistant-ui/react`, `assistant-stream`) resolve the patched release.
- Leaves `nanoid@3.3.16` (via `postcss`) unchanged; that line is already outside the vulnerable 4.x/5.x range.

## Linear
Fixes [POT-2232](https://linear.app/potpie/issue/POT-2232)

## Advisory
- https://github.com/potpie-ai/potpie-ui/security/dependabot/197
- Fixed versions: `3.3.16` or `5.1.16+`

## Test plan
- [x] `pnpm why nanoid` shows `5.1.16` (and `3.3.16` for postcss)
- [x] `pnpm run test:unit` passes
- [ ] Dependabot/Vanta high finding clears after merge

## Reviewer
Please assign review to @yashkrishan (GitHub token cannot request reviewers: 403).

## Follow-ups blocked in this environment
- Linear MCP needs desktop auth to move POT-2232 to In Progress and comment with this PR URL.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2232](https://linear.app/potpie/issue/POT-2232/vanta-potpie-aipotpie-ui-high-vulnerabilities-1)

<div><a href="https://cursor.com/agents/bc-916f583f-1bf9-43cf-82a3-267fcbe7ea98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916f583f-1bf9-43cf-82a3-267fcbe7ea98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal package version override to ensure consistent dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->