### PR TITLE
fix(security): bump js-yaml to 4.3.1 for high Vanta findings (POT-2265)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
       "@isaacs/brace-expansion": "^5.0.1",
       "brace-expansion": "5.0.9",
       "sharp": "0.35.3",
-      "js-yaml": "^4.2.0",
+      "js-yaml": "4.3.1",
       "prismjs": "^1.30.0",
       "dompurify": "^3.4.13",
       "lodash-es": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   '@isaacs/brace-expansion': ^5.0.1
   brace-expansion: 5.0.9
   sharp: 0.35.3
-  js-yaml: ^4.2.0
+  js-yaml: 4.3.1
   prismjs: ^1.30.0
   dompurify: ^3.4.13
   lodash-es: ^4.18.1
@@ -3745,8 +3745,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5570,7 +5570,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8439,7 +8439,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -9020,7 +9020,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Remediates the Vanta high-severity findings for **POT-2265**.

1. **js-yaml** `>= 4.0.0, < 4.3.1` ([Dependabot #198](https://github.com/potpie-ai/potpie-ui/security/dependabot/198)): pin `pnpm.overrides` from `^4.2.0` (resolved `4.3.0`) → `4.3.1` to fix quadratic CPU consumption in `!!omap` resolution ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)).
2. **CVE-2026-67213** / **nanoid** `< 3.3.17` ([Dependabot #199](https://github.com/potpie-ai/potpie-ui/security/dependabot/199)): already remediated on `main` via existing overrides `nanoid@<4.0.0` → `3.3.18` and `nanoid@>=4.0.0 <5.1.16` → `5.1.16` ([#455](https://github.com/potpie-ai/potpie-ui/pull/455) / [#452](https://github.com/potpie-ai/potpie-ui/pull/452)). Verified in this PR’s lockfile; no further nanoid change required.

Linear: [POT-2265](https://linear.app/potpie/issue/POT-2265)

## Test plan
- [x] `pnpm install` resolves `js-yaml@4.3.1`, `nanoid@3.3.18`, `nanoid@5.1.16`
- [x] `pnpm audit --audit-level=high` reports no known vulnerabilities
- [x] `pnpm test:unit` passes
- [ ] CI green
- [ ] Dependabot alerts #198 / #199 close after GitHub/Vanta rescan

## Review
Please review: @yashkrishan (yashkrishan@potpie.ai)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2265](https://linear.app/potpie/issue/POT-2265/vanta-potpie-aipotpie-ui-high-vulnerabilities-2)

<div><a href="https://cursor.com/agents/bc-d18e0115-afe8-405b-b25b-a39fd4fdf3db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d18e0115-afe8-405b-b25b-a39fd4fdf3db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `js-yaml` version to 4.3.1 for more consistent dependency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->