### PR TITLE
fix(security): pin js-yaml 4.3.1 for high Vanta finding (POT-2312)

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.3",
     "husky": "^9.1.7",
+    "js-yaml": "4.3.1",
     "lint-staged": "^15.5.0",
     "postcss": "8.5.23",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      js-yaml:
+        specifier: 4.3.1
+        version: 4.3.1
       lint-staged:
         specifier: ^15.5.0
         version: 15.5.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Remediates the Vanta high-severity finding for **POT-2312**.

1. **js-yaml** `>= 4.0.0, < 4.3.1` ([Dependabot #198](https://github.com/potpie-ai/potpie-ui/security/dependabot/198)): add `js-yaml@4.3.1` as a direct `devDependency` so GitHub/Vanta scanners see the patched release in `package.json`, not only via `pnpm.overrides`. This remediates quadratic CPU consumption in `!!omap` resolution ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)).
2. The `pnpm.overrides` pin `js-yaml: 4.3.1` remains in place (already on `main` via [#456](https://github.com/potpie-ai/potpie-ui/pull/456) / POT-2265). `pnpm why js-yaml` resolves a single version: **4.3.1**.

Linear: [POT-2312](https://linear.app/potpie/issue/POT-2312)

## Test plan
- [x] `pnpm why js-yaml` reports only `4.3.1`
- [x] `pnpm audit --audit-level=high` reports no known vulnerabilities
- [x] `pnpm test:unit` passes
- [ ] CI green
- [ ] Dependabot alert #198 closes after GitHub/Vanta rescan

## Review
Please review: @yashkrishan (yashkrishan@potpie.ai)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POT-2312](https://linear.app/potpie/issue/POT-2312/vanta-potpie-aipotpie-ui-high-vulnerabilities-1)

<div><a href="https://cursor.com/agents/bc-31ef1caf-8208-45e0-856a-3782a8b09a3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31ef1caf-8208-45e0-856a-3782a8b09a3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

